### PR TITLE
Release 2.3.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,11 @@
-2.2.1:
+2.3.0:
 Bug Fixes:
 * The get_yaml_data helper function now contains ruamel.yaml errors/warnings
   without disrupting calling context handlers.
+
+Enhancements:
+* yaml-paths version 0.2.0 now has more detailed output control, trading
+  --pathonly for --values, --nofile, --noexpression, and --noyamlpath.
 
 2.2.0:
 Bug Fixes:

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+2.2.1:
+Bug Fixes:
+* The get_yaml_data helper function now contains ruamel.yaml errors/warnings
+  without disrupting calling context handlers.
+
 2.2.0:
 Bug Fixes:
 * YAML construction errors are now caught and more cleanly reported by all

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="yamlpath",
-    version="2.2.0",
+    version="2.2.1",
     description="Read and change YAML/Compatible data using powerful, intuitive, command-line friendly syntax",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="yamlpath",
-    version="2.2.1",
+    version="2.3.0",
     description="Read and change YAML/Compatible data using powerful, intuitive, command-line friendly syntax",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_commands_yaml_paths.py
+++ b/tests/test_commands_yaml_paths.py
@@ -445,7 +445,7 @@ class Test_yaml_paths():
         yaml_file2 = create_temp_yaml_file(tmp_path_factory, content2)
         result = script_runner.run(
             self.command,
-            "--pathsep=/", "--keynames", "--pathonly",
+            "--pathsep=/", "--keynames", "--noexpression",
             "--search", "^value",
             "--search", "=bravo",
             yaml_file1, yaml_file2
@@ -571,7 +571,7 @@ class Test_yaml_paths():
         yaml_file = create_temp_yaml_file(tmp_path_factory, content)
         result = script_runner.run(
             self.command,
-            "--pathsep=/", "--keynames", "--pathonly",
+            "--pathsep=/", "--keynames", "--noexpression",
             "--search", "=key",
             "--search", "=value",
             yaml_file
@@ -882,3 +882,25 @@ class Test_yaml_paths():
             include_key_aliases=False, include_value_aliases=False
         )):
             assert assertion == str(path)
+
+    def test_value_dump(self, script_runner, tmp_path_factory):
+        content = """---
+        sample_scalar: value
+        sample_hash:
+          sub:
+            - list
+            - elements
+        """
+        yaml_file = create_temp_yaml_file(tmp_path_factory, content)
+        result = script_runner.run(
+            self.command,
+            "--pathsep=/",
+            "--keynames", "--values",
+            "--search", "^sample",
+            yaml_file
+        )
+        assert result.success, result.stderr
+        assert "\n".join([
+            "/sample_scalar: value",
+            '/sample_hash: {"sub": ["list", "elements"]}',
+        ]) + "\n" == result.stdout

--- a/yamlpath/commands/yaml_paths.py
+++ b/yamlpath/commands/yaml_paths.py
@@ -34,7 +34,7 @@ from yamlpath.wrappers import ConsolePrinter
 from yamlpath.eyaml import EYAMLProcessor
 
 # Implied Constants
-MY_VERSION = "0.1.0"
+MY_VERSION = "0.2.0"
 
 def processcli():
     """Process command-line arguments."""

--- a/yamlpath/commands/yaml_paths.py
+++ b/yamlpath/commands/yaml_paths.py
@@ -555,7 +555,7 @@ def search_for_paths(logger: ConsolePrinter, processor: EYAMLProcessor,
                             include_value_aliases=include_value_aliases):
                         yield path
                 else:
-                    yield tmp_path
+                    yield YAMLPath(tmp_path)
                 continue
 
             if isinstance(val, (CommentedSeq, CommentedMap)):

--- a/yamlpath/func.py
+++ b/yamlpath/func.py
@@ -56,7 +56,7 @@ def get_yaml_editor() -> Any:
     yaml.width = maxsize            # type: ignore
     return yaml
 
-# pylint: disable=locally-disabled,too-many-branches
+# pylint: disable=locally-disabled,too-many-branches,too-many-statements
 def get_yaml_data(parser: Any, logger: ConsolePrinter, source: str) -> Any:
     """
     Attempts to parse YAML/Compatible data and return the ruamel.yaml object
@@ -66,13 +66,17 @@ def get_yaml_data(parser: Any, logger: ConsolePrinter, source: str) -> Any:
     the data could not be loaded.
     """
     import warnings
-    warnings.filterwarnings("error")
     yaml_data = None
 
-    # Try to open the file
+    # This code traps errors and warnings from ruamel.yaml, substituting
+    # lengthy stack-dumps with specific, meaningful feedback.  Further, some
+    # warnings are treated as errors by ruamel.yaml, so these are also
+    # coallesced into cleaner feedback.
     try:
         with open(source, 'r') as fhnd:
-            yaml_data = parser.load(fhnd)
+            with warnings.catch_warnings():
+                warnings.filterwarnings("error")
+                yaml_data = parser.load(fhnd)
     except KeyboardInterrupt:
         logger.error("Aborting data load due to keyboard interrupt!")
         yaml_data = None

--- a/yamlpath/func.py
+++ b/yamlpath/func.py
@@ -47,11 +47,13 @@ def get_yaml_editor() -> Any:
 
     Raises:  N/A
     """
+    # The ruamel.yaml class appears to be missing some typing data, so these
+    # valid assignments cannot be type-checked.
     yaml = YAML()
     yaml.indent(mapping=2, sequence=4, offset=2)
-    yaml.explicit_start = True
-    yaml.preserve_quotes = True
-    yaml.width = maxsize
+    yaml.explicit_start = True      # type: ignore
+    yaml.preserve_quotes = True     # type: ignore
+    yaml.width = maxsize            # type: ignore
     return yaml
 
 # pylint: disable=locally-disabled,too-many-branches

--- a/yamlpath/patches/emitter_write_folded_fix.py
+++ b/yamlpath/patches/emitter_write_folded_fix.py
@@ -86,4 +86,6 @@ def write_folded_fix(self, text):
         end += 1
 
 
-Emitter.write_folded = write_folded_fix
+# MYPY hates MonkeyPatching per https://github.com/python/mypy/issues/2427
+# but there's no choice here, so... ignore the type.
+Emitter.write_folded = write_folded_fix     # type: ignore


### PR DESCRIPTION
2.3.0:
Bug Fixes:
* The get_yaml_data helper function now contains ruamel.yaml errors/warnings
  without disrupting calling context handlers.

Enhancements:
* yaml-paths version 0.2.0 now has more detailed output control, trading
  --pathonly for --values, --nofile, --noexpression, and --noyamlpath.