### PR TITLE
Add support for setting a block of yaml

### DIFF
--- a/tests/test_commands_yaml_set.py
+++ b/tests/test_commands_yaml_set.py
@@ -433,3 +433,25 @@ class Test_yaml_set():
         with open(backup_file, 'r') as fhnd:
             filedat = fhnd.read()
         assert filedat == content
+
+    def test_invalid_yaml_value(self, script_runner, tmp_path_factory):
+        content = """---
+        key: value
+        """
+        yaml_file = create_temp_yaml_file(tmp_path_factory, content)
+
+        result = script_runner.run(self.command, "--yaml", "--change=/key", "--value={foo: bar", yaml_file)
+        assert not result.success, result.stderr
+        assert "YAML parsing error" in result.stderr
+
+    def test_invalid_yaml_file(self, script_runner, tmp_path_factory, imparsible_yaml_file):
+        content = """---
+        key: value
+        """
+        yaml_file = create_temp_yaml_file(tmp_path_factory, content)
+
+        result = script_runner.run(self.command, "--yaml", "--change=/key", "--file={}".format(imparsible_yaml_file), yaml_file)
+        assert not result.success, result.stderr
+        assert "YAML parsing error" in result.stderr
+
+

--- a/yamlpath/commands/yaml_set.py
+++ b/yamlpath/commands/yaml_set.py
@@ -11,6 +11,7 @@ import sys
 import argparse
 import secrets
 import string
+import io
 from os import remove, access, R_OK
 from os.path import isfile, exists
 from shutil import copy2
@@ -70,6 +71,9 @@ def processcli():
         type=int,
         metavar="LENGTH",
         help="randomly generate a replacement value of a set length")
+    parser.add_argument(
+        "-y", "--yaml", action="store_true",
+        help="the input is a yaml string and should be parsed and merged")
 
     parser.add_argument(
         "-F", "--format",
@@ -196,6 +200,11 @@ def main():
                 string.ascii_uppercase + string.ascii_lowercase + string.digits
             ) for _ in range(args.random)
         )
+    if args.yaml:
+        buf = io.StringIO()
+        buf.write(new_value)
+        buf.seek(0)
+        new_value = get_yaml_editor().load(buf)
 
     # Prep the YAML parser
     yaml = get_yaml_editor()

--- a/yamlpath/commands/yaml_set.py
+++ b/yamlpath/commands/yaml_set.py
@@ -149,6 +149,18 @@ def validateargs(args, log):
             "Exactly one of the following must be set:  --value, --file,"
             + " --stdin, or --random")
 
+    # * We do not support random YAML values
+    if args.yaml and args.random is not None:
+        has_errors = True
+        log.error(
+            "The following options are not compatible: --yaml, --random")
+
+    # * The format of the input YAML will be preserved, so this option shouldn't be used with --yaml
+    if args.yaml and args.format != "default":
+        has_errors = True
+        log.error(
+            "The following options are not compatible: --yaml, --format")
+
     # * When set, --saveto cannot be identical to --change
     if args.saveto and args.saveto == args.change:
         has_errors = True
@@ -208,7 +220,6 @@ def main():
         buf.write(new_value)
         buf.seek(0)
         new_value = get_yaml_data(yaml, log, buf)
-
 
     # Attempt to open the YAML file; check for parsing errors
     yaml_data = get_yaml_data(yaml, log, args.yaml_file)

--- a/yamlpath/commands/yaml_set.py
+++ b/yamlpath/commands/yaml_set.py
@@ -200,14 +200,15 @@ def main():
                 string.ascii_uppercase + string.ascii_lowercase + string.digits
             ) for _ in range(args.random)
         )
+
+    # Prep the YAML parser
+    yaml = get_yaml_editor()
     if args.yaml:
         buf = io.StringIO()
         buf.write(new_value)
         buf.seek(0)
-        new_value = get_yaml_editor().load(buf)
+        new_value = get_yaml_data(yaml, log, buf)
 
-    # Prep the YAML parser
-    yaml = get_yaml_editor()
 
     # Attempt to open the YAML file; check for parsing errors
     yaml_data = get_yaml_data(yaml, log, args.yaml_file)

--- a/yamlpath/func.py
+++ b/yamlpath/func.py
@@ -73,7 +73,9 @@ def get_yaml_data(parser: Any, logger: ConsolePrinter, source: str) -> Any:
     # warnings are treated as errors by ruamel.yaml, so these are also
     # coallesced into cleaner feedback.
     try:
-        with open(source, 'r') as fhnd:
+        content = source if hasattr(source, 'read') else open(source, 'r')
+
+        with content as fhnd:
             with warnings.catch_warnings():
                 warnings.filterwarnings("error")
                 yaml_data = parser.load(fhnd)


### PR DESCRIPTION
Co-authored-by: Jonathan Radon <jon@radonfamily.com>

Hey there - this is super not done yet - we need to add tests and error handling, and we don't write a lot of python, so there's probably plenty to improve, but we thought we'd try to start the conversation early.

This adds the ability to add a block of yaml (or, I suppose json) to an existing file instead of a single value.

Any thoughts as we continue with it?