### PR TITLE
Release 2.4.2

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,10 @@
+2.4.1:
+Bug Fixes:
+* The yaml-merge tool (and underlying Merger class) incorrectly assigned "None"
+  Anchors to all floating-point numbers.  This preventing all merging when both
+  the LHS and RHS documents contained at least one floating-point number, each.
+  The yaml-merge command now reports version 0.0.2 to reflect this change.
+
 2.4.0:
 Enhancements:
 * Added new reference command-line tool:  yaml-merge.  This is a very complex

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,17 @@
+2.4.2:
+Enhancements:
+* In the INI file's [rules] section, different merge rules can now be applied
+  to specific parts -- no matter how deeply nested -- of the same Hash
+  structure.
+
+Bug Fixes:
+* The 3rd-party Python INI file parser had no way of differentiating between
+  the key and value of a YAML Path entry containing an = sign in its key, like
+  "/path[.=name]/key = left".  This update reconstitutes such lines and
+  correctly parses an affected YAML Path from the merge rule.
+
+The yaml-merge command now reports version 0.0.3 to reflect these changes.
+
 2.4.1:
 Bug Fixes:
 * The yaml-merge tool (and underlying Merger class) incorrectly assigned "None"

--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,7 @@
 2.4.1:
 Bug Fixes:
 * The yaml-merge tool (and underlying Merger class) incorrectly assigned "None"
-  Anchors to all floating-point numbers.  This preventing all merging when both
+  Anchors to all floating-point numbers.  This prevented all merging when both
   the LHS and RHS documents contained at least one floating-point number, each.
   The yaml-merge command now reports version 0.0.2 to reflect this change.
 

--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,45 @@ Enhancements:
   YAML_FILE input arguments is -.  No other reference command-line tools
   support this change at this time.
 
+Known Issues:
+1. Neither yaml-set nor yaml-merge will add override keys to a Hash which uses
+   the YAML merge operator (<<:) and which does not already have a matching
+   override key.  This issue has existed for a very long time but was only
+   discovered during preparation for this release.  This will be logged and
+   tracked as a Known Issue for this release -- to be fixed at another time --
+   because no one (not even myself) has yet encountered/reported this issue, it
+   is non-trivial to fix, and it is an edge-case.  Here is an example of this
+   issue:
+
+   For ex.yaml:
+   ---
+   anchored_hash: &its_anchor
+     ah_key: Base value
+   merging_hash:
+     <<: *its_anchor
+     mh_key: Implementation value
+
+   ... both of these commands:
+   `yaml-set --change=/merging_hash/ah_key --value='Override value' ex.yaml`
+   `echo 'Override value' | yaml-merge -m /merging_hash/ah_key ex.yaml -`
+
+   ... will fail to affect the expected change.  The expectation would be:
+   ---
+   anchored_hash: &its_anchor
+     ah_key: Base value
+   merging_hash:
+     <<: *its_anchor
+     mh_key: Implementation value
+     ah_key: Override value
+
+   ... but the actual result is (without any indication of an error):
+   ---
+   anchored_hash: &its_anchor
+     ah_key: Base value
+   merging_hash:
+     <<: *its_anchor
+     mh_key: Implementation value
+
 2.3.7:
 Bug Fixes:
 * Setting negative floats could cause the leading "-" symbol to be replaced

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ for other projects to readily employ YAML Paths.
       2. [Get a YAML Value](#get-a-yaml-value)
       3. [Search For YAML Paths](#search-for-yaml-paths)
       4. [Change a YAML Value](#change-a-yaml-value)
+      5. [Merge YAML/Compatible Files](#merge-yaml-compatible-files)
    2. [Basic Usage:  Libraries](#basic-usage--libraries)
       1. [Initialize ruamel.yaml and These Helpers](#initialize-ruamelyaml-and-these-helpers)
       2. [Searching for YAML Nodes](#searching-for-yaml-nodes)
@@ -374,6 +375,76 @@ EYAML options:
 
 For more information about YAML Paths, please visit
 https://github.com/wwkimball/yamlpath.
+```
+* [yaml-merge](yamlpath/commands/yaml_merge.py)
+
+```text
+usage: yaml-merge [-h] [-V] [-c CONFIG] [-a {stop,left,right,rename}]
+                  [-A {all,left,right,unique}] [-H {deep,left,right}]
+                  [-O {all,deep,left,right,unique}] [-m YAML_PATH] [-o OUTPUT]
+                  [-d | -v | -q]
+                  YAML_FILE [YAML_FILE ...]
+
+Merges two or more YAML/Compatible files together.
+
+positional arguments:
+  YAML_FILE             one or more YAML files to merge, order-significant;
+                        use - to read from STDIN
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -V, --version         show program's version number and exit
+  -c CONFIG, --config CONFIG
+                        INI syle configuration file for YAML Path specified
+                        merge control options
+  -a {stop,left,right,rename}, --anchors {stop,left,right,rename}
+                        means by which Anchor name conflicts are resolved
+                        (overrides [defaults]anchors set via --config|-c and
+                        cannot be overridden by [rules] because Anchors apply
+                        to the whole file); default=stop
+  -A {all,left,right,unique}, --arrays {all,left,right,unique}
+                        default means by which Arrays are merged together
+                        (overrides [defaults]arrays but is overridden on a
+                        YAML Path basis via --config|-c); default=all
+  -H {deep,left,right}, --hashes {deep,left,right}
+                        default means by which Hashes are merged together
+                        (overrides [defaults]hashes but is overridden on a
+                        YAML Path basis in [rules] set via --config|-c);
+                        default=deep
+  -O {all,deep,left,right,unique}, --aoh {all,deep,left,right,unique}
+                        default means by which Arrays-of-Hashes are merged
+                        together (overrides [defaults]aoh but is overridden on
+                        a YAML Path basis in [rules] set via --config|-c);
+                        default=all
+  -m YAML_PATH, --mergeat YAML_PATH
+                        YAML Path indicating where in left YAML_FILE the right
+                        YAML_FILE content is to be merged; default=/
+  -o OUTPUT, --output OUTPUT
+                        Write the merged result to the indicated file (or
+                        STDOUT when unset)
+  -d, --debug           output debugging details
+  -v, --verbose         increase output verbosity
+  -q, --quiet           suppress all output except errors (implied when
+                        -o|--output is not set)
+
+            The CONFIG file is an INI file with up to three sections:
+            [defaults] Sets equivalents of -a|--anchors, -A|--arrays,
+                       -H|--hashes, and -O|--aoh.
+            [rules]    Each entry is a YAML Path assigning -A|--arrays,
+                       -H|--hashes, or -O|--aoh for precise nodes.
+            [keys]     Wherever -O|--aoh=DEEP, each entry is treated as a
+                       record with an identity key.  In order to match RHS
+                       records to LHS records, a key must be known and is
+                       identified on a YAML Path basis via this section.
+                       Where not specified, the first attribute of the first
+                       record in the Array-of-Hashes is presumed the identity
+                       key for all records in the set.
+
+            The left-to-right order of YAML_FILEs is significant.  Except
+            when this behavior is deliberately altered by your options, data
+            from files on the right overrides data in files to their left.
+            For more information about YAML Paths, please visit
+            https://github.com/wwkimball/yamlpath.
 ```
 
 * [yaml-paths](yamlpath/commands/yaml_paths.py)
@@ -722,6 +793,60 @@ your command-line, process list, and command history by swapping out `--value`
 for one of `--stdin`, `--file`, or even `--random LENGTH` (use Python's
 strongest random value generator if you don't need to specify the replacement
 value in advance).
+
+#### Merge YAML/Compatible Files
+
+At its simplest, the `yaml-merge` command accepts two or more input files and
+merges them together from left-to-right, writing the result to STDOUT:
+
+```shell
+yaml-merge leftmost.yaml middle.yaml right.json
+```
+
+If you'd rather write the results to a new output file (which must not already
+exist):
+
+```shell
+yaml-merge \
+  --output=newfile.yaml \
+  leftmost.yaml \
+  middle.yaml \
+  right.json
+```
+
+Should you wish to merge the content of the files into a specific location (or
+even multiple locations) within the leftmost document, specify a YAML Path via
+the `--mergeat` or `-m` argument:
+
+```shell
+yaml-merge \
+  --mergeat=/anywhere/within/the/document \
+  leftmost.yaml \
+  middle.yaml \
+  right.json
+```
+
+To write arbitrary data from STDIN into a document, use the `-` pseudo-file:
+
+```shell
+echo "{arbitrary: [document, structure]}" | yaml-merge target.yaml -
+```
+
+Combine `--mergeat` or `-m` with the STDIN pseudo-file to control where the
+data is to be written:
+
+```shell
+echo "{arbitrary: [document, structure]}" | \
+  yaml-merge \
+    --mergeat=/anywhere/within/the/document \
+    target.yaml -
+```
+
+There are many options for precisely controlling how the merge is performed,
+including the ability to specify complex rules on a YAML Path basis via a
+configuration file.  Review the command's `--help` or the
+[related Wiki](https://github.com/wwkimball/yamlpath/wiki/yaml-merge) for
+more detail.
 
 ### Basic Usage:  Libraries
 

--- a/build-release-artifacts.sh
+++ b/build-release-artifacts.sh
@@ -21,17 +21,16 @@ python3 setup.py sdist bdist_wheel || exit $?
 
 # Generate a ZIP file for Windows users
 cd dist || exit 2
-relname=$(basename $(ls -1 *.tar.gz) .tar.gz)
+relname=$(basename $(ls -1 ./*.tar.gz) .tar.gz)
 mkdir win \
-	&& cp ${relname}.tar.gz win/ \
+	&& cp "${relname}.tar.gz" win/ \
 	&& cd win/ \
-	&& tar xvzf *.tar.gz \
-	&& rm -f *.gz \
-	&& zip --recurse-paths --test --verbose ${relname}.zip ${relname}/ \
-	&& mv *.zip .. \
+	&& tar xvzf ./*.tar.gz \
+	&& rm -f ./*.gz \
+	&& zip --recurse-paths --test --verbose "${relname}.zip" "${relname}"/ \
+	&& mv ./*.zip .. \
 	&& cd .. \
 	&& rm -rf win
 
 # Show the final release artifacts
-ls -1 *
-
+ls -1 ./*

--- a/build-release-artifacts.sh
+++ b/build-release-artifacts.sh
@@ -6,8 +6,8 @@
 [ -e dist ] && rm -rf dist
 
 # Update pip and install release tools
-python -m pip install --upgrade pip
-pip install wheel || exit $?
+python3 -m pip install --upgrade pip
+pip3 install wheel || exit $?
 
 # Require successful tests
 if [ ! -x run-tests.sh ]; then

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="yamlpath",
-    version="2.4.0",
+    version="2.4.1",
     description="Read and change YAML/Compatible data using powerful, intuitive, command-line friendly syntax",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="yamlpath",
-    version="2.4.1",
+    version="2.4.2",
     description="Read and change YAML/Compatible data using powerful, intuitive, command-line friendly syntax",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_merger_merger.py
+++ b/tests/test_merger_merger.py
@@ -1456,10 +1456,11 @@ merge_key: *shared_anchor_1
         """
         While it is impossible to overwrite an Array with a Hash because that
         would be a total loss of data, it is possible to append a Hash to an
-        Array.  This is admittedly an odd case.  It is very likely this is the
-        result of user-error, having provided a silly mergeat argument.  But
-        because the result is a complete preservation of all data from both the
-        LHS and RHS data sources, it is permitted.
+        Array (this is different from merging into an Array-of-Hashes, which is
+        normal and allowed).  This is admittedly an odd case.  It is very
+        likely this is the result of user-error, having provided a silly
+        mergeat argument.  But because the result is a complete preservation of
+        all data from both the LHS and RHS data sources, it is permitted.
 
         A deliberately odd mergeat is provided to force this case.
         """
@@ -2006,7 +2007,6 @@ hash:
             and (open(output_file,'r').read() == open(merged_yaml,'r').read())
         )
 
-
     def test_merge_rename_anchored_hash_value(
         self, quiet_logger, tmp_path, tmp_path_factory
     ):
@@ -2058,6 +2058,289 @@ records:
         rhs_data = get_yaml_data(rhs_yaml, quiet_logger, rhs_yaml_file)
 
         args = SimpleNamespace(anchors="rename")
+        mc = MergerConfig(quiet_logger, args)
+        merger = Merger(quiet_logger, lhs_data, mc)
+        merger.merge_with(rhs_data)
+
+        with open(output_file, 'w') as yaml_dump:
+            lhs_yaml.dump(merger.data, yaml_dump)
+
+        # DEBUG:
+        # with open(output_file, 'r') as output_fnd, open(merged_yaml, 'r') as merged_fnd:
+        #     print("Expected:")
+        #     print(merged_fnd.read())
+        #     print("Got:")
+        #     print(output_fnd.read())
+
+        assert (
+            (os.path.getsize(output_file) == os.path.getsize(merged_yaml))
+            and (open(output_file,'r').read() == open(merged_yaml,'r').read())
+        )
+
+    def test_merge_hash_with_mergeat_default(
+        self, quiet_logger, tmp_path, tmp_path_factory
+    ):
+        lhs_yaml_file = create_temp_yaml_file(tmp_path_factory, """---
+hash:
+  key: value
+""")
+        rhs_yaml_file = create_temp_yaml_file(tmp_path_factory, """---
+more_hash:
+  key: more value
+""")
+        merged_yaml = create_temp_yaml_file(tmp_path_factory, """---
+hash:
+  key: value
+implicit:
+  structure:
+    to:
+      more_hash:
+        key: more value
+""")
+
+        output_dir = tmp_path / "test_merge_hash_with_mergeat_default"
+        output_dir.mkdir()
+        output_file = output_dir / "output.yaml"
+
+        lhs_yaml = get_yaml_editor()
+        rhs_yaml = get_yaml_editor()
+        lhs_data = get_yaml_data(lhs_yaml, quiet_logger, lhs_yaml_file)
+        rhs_data = get_yaml_data(rhs_yaml, quiet_logger, rhs_yaml_file)
+
+        args = SimpleNamespace(mergeat="/implicit/structure/to")
+        mc = MergerConfig(quiet_logger, args)
+        merger = Merger(quiet_logger, lhs_data, mc)
+        merger.merge_with(rhs_data)
+
+        with open(output_file, 'w') as yaml_dump:
+            lhs_yaml.dump(merger.data, yaml_dump)
+
+        # DEBUG:
+        with open(output_file, 'r') as output_fnd, open(merged_yaml, 'r') as merged_fnd:
+            print("Expected:")
+            print(merged_fnd.read())
+            print("Got:")
+            print(output_fnd.read())
+
+        assert (
+            (os.path.getsize(output_file) == os.path.getsize(merged_yaml))
+            and (open(output_file,'r').read() == open(merged_yaml,'r').read())
+        )
+
+    def test_merge_hash_with_mergeat_left(
+        self, quiet_logger, tmp_path, tmp_path_factory
+    ):
+        lhs_yaml_file = create_temp_yaml_file(tmp_path_factory, """---
+hash:
+  key: value
+""")
+        rhs_yaml_file = create_temp_yaml_file(tmp_path_factory, """---
+more_hash:
+  key: more value
+""")
+        merged_yaml = create_temp_yaml_file(tmp_path_factory, """---
+hash:
+  key: value
+implicit:
+  structure:
+    to:
+      more_hash:
+        key: more value
+""")
+
+        output_dir = tmp_path / "test_merge_hash_with_mergeat_left"
+        output_dir.mkdir()
+        output_file = output_dir / "output.yaml"
+
+        lhs_yaml = get_yaml_editor()
+        rhs_yaml = get_yaml_editor()
+        lhs_data = get_yaml_data(lhs_yaml, quiet_logger, lhs_yaml_file)
+        rhs_data = get_yaml_data(rhs_yaml, quiet_logger, rhs_yaml_file)
+
+        args = SimpleNamespace(hashes="left", mergeat="/implicit/structure/to")
+        mc = MergerConfig(quiet_logger, args)
+        merger = Merger(quiet_logger, lhs_data, mc)
+        merger.merge_with(rhs_data)
+
+        with open(output_file, 'w') as yaml_dump:
+            lhs_yaml.dump(merger.data, yaml_dump)
+
+        # DEBUG:
+        with open(output_file, 'r') as output_fnd, open(merged_yaml, 'r') as merged_fnd:
+            print("Expected:")
+            print(merged_fnd.read())
+            print("Got:")
+            print(output_fnd.read())
+
+        assert (
+            (os.path.getsize(output_file) == os.path.getsize(merged_yaml))
+            and (open(output_file,'r').read() == open(merged_yaml,'r').read())
+        )
+
+    def test_merge_hash_with_mergeat_right(
+        self, quiet_logger, tmp_path, tmp_path_factory
+    ):
+        lhs_yaml_file = create_temp_yaml_file(tmp_path_factory, """---
+hash:
+  key: value
+""")
+        rhs_yaml_file = create_temp_yaml_file(tmp_path_factory, """---
+more_hash:
+  key: more value
+""")
+        merged_yaml = create_temp_yaml_file(tmp_path_factory, """---
+hash:
+  key: value
+implicit:
+  structure:
+    to:
+      more_hash:
+        key: more value
+""")
+
+        output_dir = tmp_path / "test_merge_hash_with_mergeat_right"
+        output_dir.mkdir()
+        output_file = output_dir / "output.yaml"
+
+        lhs_yaml = get_yaml_editor()
+        rhs_yaml = get_yaml_editor()
+        lhs_data = get_yaml_data(lhs_yaml, quiet_logger, lhs_yaml_file)
+        rhs_data = get_yaml_data(rhs_yaml, quiet_logger, rhs_yaml_file)
+
+        args = SimpleNamespace(hashes="right", mergeat="/implicit/structure/to")
+        mc = MergerConfig(quiet_logger, args)
+        merger = Merger(quiet_logger, lhs_data, mc)
+        merger.merge_with(rhs_data)
+
+        with open(output_file, 'w') as yaml_dump:
+            lhs_yaml.dump(merger.data, yaml_dump)
+
+        # DEBUG:
+        with open(output_file, 'r') as output_fnd, open(merged_yaml, 'r') as merged_fnd:
+            print("Expected:")
+            print(merged_fnd.read())
+            print("Got:")
+            print(output_fnd.read())
+
+        assert (
+            (os.path.getsize(output_file) == os.path.getsize(merged_yaml))
+            and (open(output_file,'r').read() == open(merged_yaml,'r').read())
+        )
+
+    def test_merge_with_complex_hash_rules(
+        self, quiet_logger, tmp_path, tmp_path_factory
+    ):
+        config_file = create_temp_yaml_file(tmp_path_factory, """
+[defaults]
+hashes = deep
+
+[rules]
+/hash/structure/with/several = left
+/hash/even = right
+/hash/blah = left
+/hash/fu = left
+/hash/la = right
+/hash/ri/fa = left
+/force_left = left
+/force_right = right
+""")
+        lhs_yaml_file = create_temp_yaml_file(tmp_path_factory, """---
+hash:
+  structure:
+    with:
+      several: LHS (several)
+      keep: LHS (keep)
+    and:
+      data: LHS (data)
+  even: LHS (even)
+  blah:
+    tee: LHS (tee)
+  fu:
+    ru: LHS (ru)
+    tu: LHS (tu)
+  la:
+    ta: LHS (ta)
+    da: LHS (da)
+  ri:
+    me:
+      do: LHS (do)
+      po: LHS (po)
+    fa:
+      so: LHS (so)
+lhs_exclusive:
+  key: LHS (key)
+force_left: true
+force_right: false
+""")
+        rhs_yaml_file = create_temp_yaml_file(tmp_path_factory, """---
+hash:
+  structure:
+    with:
+      several: RHS (several)
+      having: RHS (having)
+      keep: RHS (keep)
+  fu:
+    do: RHS (do)
+    re: RHS (re)
+  more: RHS (more)
+  even: RHS (even)
+  la:
+    bi: RHS (bi)
+    ti: RHS (ti)
+  blah:
+    ree: RHS (ree)
+  ri:
+    fa:
+      re: RHS (re)
+      be: RHS (be)
+rhs_exclusive:
+  another_key: RHS (another_key)
+force_left: false
+force_right: true
+""")
+        merged_yaml = create_temp_yaml_file(tmp_path_factory, """---
+hash:
+  structure:
+    with:
+      several: LHS (several)
+      having: RHS (having)
+      keep: RHS (keep)
+    and:
+      data: LHS (data)
+  even: RHS (even)
+  more: RHS (more)
+  blah:
+    tee: LHS (tee)
+  fu:
+    ru: LHS (ru)
+    tu: LHS (tu)
+  la:
+    bi: RHS (bi)
+    ti: RHS (ti)
+  ri:
+    me:
+      do: LHS (do)
+      po: LHS (po)
+    fa:
+      so: LHS (so)
+lhs_exclusive:
+  key: LHS (key)
+rhs_exclusive:
+  another_key: RHS (another_key)
+force_left: true
+force_right: true
+""")
+
+        output_dir = tmp_path / "test_merge_with_complex_hash_rules"
+        output_dir.mkdir()
+        output_file = output_dir / "output.yaml"
+
+        lhs_yaml = get_yaml_editor()
+        rhs_yaml = get_yaml_editor()
+        lhs_data = get_yaml_data(lhs_yaml, quiet_logger, lhs_yaml_file)
+        rhs_data = get_yaml_data(rhs_yaml, quiet_logger, rhs_yaml_file)
+
+        args = SimpleNamespace(config=config_file)
         mc = MergerConfig(quiet_logger, args)
         merger = Merger(quiet_logger, lhs_data, mc)
         merger.merge_with(rhs_data)

--- a/tests/test_merger_merger.py
+++ b/tests/test_merger_merger.py
@@ -318,6 +318,54 @@ hash:
             and (open(output_file,'r').read() == open(merged_yaml,'r').read())
         )
 
+    def test_merge_with_defaults_array_of_floats(
+        self, quiet_logger, tmp_path, tmp_path_factory
+    ):
+        lhs_yaml_file = create_temp_yaml_file(tmp_path_factory, """---
+- 1.1
+- 2.2
+""")
+        rhs_yaml_file = create_temp_yaml_file(tmp_path_factory, """---
+- 2.2
+- 3.3
+""")
+        merged_yaml = create_temp_yaml_file(tmp_path_factory, """---
+  - 1.1
+  - 2.2
+  - 2.2
+  - 3.3
+""")
+
+        output_dir = tmp_path / "test_merge_with_defaults_simple_array"
+        output_dir.mkdir()
+        output_file = output_dir / "output.yaml"
+
+        lhs_yaml = get_yaml_editor()
+        rhs_yaml = get_yaml_editor()
+        lhs_data = get_yaml_data(lhs_yaml, quiet_logger, lhs_yaml_file)
+        rhs_data = get_yaml_data(rhs_yaml, quiet_logger, rhs_yaml_file)
+
+        args = SimpleNamespace()
+        mc = MergerConfig(quiet_logger, args)
+        merger = Merger(quiet_logger, lhs_data, mc)
+        merger.merge_with(rhs_data)
+
+        with open(output_file, 'w') as yaml_dump:
+            lhs_yaml.dump(merger.data, yaml_dump)
+
+        # DEBUG:
+        # with open(output_file, 'r') as output_fnd, open(merged_yaml, 'r') as merged_fnd:
+        #     print("Expected:")
+        #     print(merged_fnd.read())
+        #     print("Got:")
+        #     print(output_fnd.read())
+
+        assert (
+            (os.path.getsize(output_file) == os.path.getsize(merged_yaml))
+            and (open(output_file,'r').read() == open(merged_yaml,'r').read())
+        )
+
+
     def test_merge_with_defaults_simple_array(
         self, quiet_logger, tmp_path, tmp_path_factory
     ):

--- a/tests/test_merger_mergerconfig.py
+++ b/tests/test_merger_mergerconfig.py
@@ -513,6 +513,7 @@ class Test_merger_MergerConfig():
         config_file = create_temp_yaml_file(tmp_path_factory, """
         [rules]
         /does_not_exist = left
+        /array_of_hashes[name = "Does Not Compute"] = right
         """)
         lhs_yaml_file = create_temp_yaml_file(tmp_path_factory, """---
         hash:

--- a/tests/test_yamlpath.py
+++ b/tests/test_yamlpath.py
@@ -125,7 +125,7 @@ class Test_path_Path():
         original = YAMLPath(path)
         remove = YAMLPath(prefix) if prefix is not None else None
         compare = YAMLPath(result)
-        stripped = YAMLPath.strip_path_prefix(remove, original)
+        stripped = YAMLPath.strip_path_prefix(original, remove)
         assert compare == stripped
 
     def test_parse_double_inversion_error(self):

--- a/yamlpath/commands/yaml_merge.py
+++ b/yamlpath/commands/yaml_merge.py
@@ -25,7 +25,7 @@ from yamlpath.exceptions import YAMLPathException
 from yamlpath.wrappers import ConsolePrinter
 
 # Implied Constants
-MY_VERSION = "0.0.2"
+MY_VERSION = "0.0.3"
 
 def processcli():
     """Process command-line arguments."""

--- a/yamlpath/commands/yaml_merge.py
+++ b/yamlpath/commands/yaml_merge.py
@@ -25,7 +25,7 @@ from yamlpath.exceptions import YAMLPathException
 from yamlpath.wrappers import ConsolePrinter
 
 # Implied Constants
-MY_VERSION = "0.0.1"
+MY_VERSION = "0.0.2"
 
 def processcli():
     """Process command-line arguments."""

--- a/yamlpath/merger/merger.py
+++ b/yamlpath/merger/merger.py
@@ -433,9 +433,13 @@ class Merger:
 
         # Loop through all insertion points and the elements in RHS
         merge_performed = False
+        nodes: List[NodeCoords] = []
         for node_coord in lhs_proc.get_nodes(
                 insert_at, default_value=default_val
         ):
+            nodes.append(node_coord)
+
+        for node_coord in nodes:
             target_node = (node_coord.node
                 if isinstance(node_coord.node, (CommentedMap, CommentedSeq))
                 else node_coord.parent)

--- a/yamlpath/merger/merger.py
+++ b/yamlpath/merger/merger.py
@@ -537,7 +537,7 @@ class Merger:
             for ele in dom:
                 Merger.scan_for_anchors(ele, anchors)
 
-        elif hasattr(dom, "anchor"):
+        elif hasattr(dom, "anchor") and dom.anchor.value is not None:
             anchors[dom.anchor.value] = dom
 
     @classmethod

--- a/yamlpath/merger/mergerconfig.py
+++ b/yamlpath/merger/mergerconfig.py
@@ -205,23 +205,48 @@ class MergerConfig:
                 .format(section))
             return
 
-        for rule_str in self.config[section]:
-            rule_path = YAMLPath(rule_str)
-            yaml_path = YAMLPath.strip_path_prefix(merge_path, rule_path)
+        for rule_key in self.config[section]:
+            rule_value = self.config[section][rule_key]
+
+            if "=" in rule_value:
+                # There were at least two = signs on the configuration line
+                conf_line = rule_key + "=" + rule_value
+                delim_pos = conf_line.rfind("=")
+                rule_key = conf_line[0:delim_pos].strip()
+                rule_value = conf_line[delim_pos + 1:].strip()
+                self.log.debug(
+                    "MergerConfig::_prepare_user_rules:  Reconstituted"
+                    " configuration line '{}' to extract adjusted key '{}'"
+                    " with value '{}'".format(conf_line, rule_key, rule_value))
+
+            rule_path = YAMLPath(rule_key)
+            yaml_path = YAMLPath.strip_path_prefix(rule_path, merge_path)
             self.log.debug(
-                "MergerConfig::_prepare_user_rules:  Matching '{}' nodes to {}"
-                " from {}."
-                .format(section, yaml_path, rule_str))
+                "MergerConfig::_prepare_user_rules:  Matching '{}' nodes to"
+                " YAML Path '{}' from key, {}."
+                .format(section, yaml_path, rule_key))
             try:
                 for node_coord in proc.get_nodes(yaml_path, mustexist=True):
-                    collector[node_coord] = self.config[section][rule_str]
+                    self.log.debug(
+                        "MergerConfig::_prepare_user_rules:  Node will"
+                        " have merging rule, {}:".format(rule_value))
+                    self.log.debug(node_coord.node)
+                    collector[node_coord] = rule_value
+
             except YAMLPathException:
                 self.log.warning("{} YAML Path matches no nodes:  {}"
                                 .format(section, yaml_path))
 
         self.log.debug(
             "MergerConfig::_prepare_user_rules:  Matched rules to nodes:")
-        self.log.debug(collector)
+        for node_coord, merge_rule in collector.items():
+            self.log.debug("... RULE:  {}".format(merge_rule))
+            self.log.debug("... NODE:")
+            self.log.debug(node_coord.node)
+            self.log.debug("... PARENT:")
+            self.log.debug(node_coord.parent)
+            self.log.debug("... REF:")
+            self.log.debug(node_coord.parentref)
 
     def _load_config(self) -> None:
         """Load the external configuration file."""
@@ -268,6 +293,13 @@ class MergerConfig:
 
         Returns: (str) The requested configuration.
         """
+        self.log.debug("MergerConfig::_get_rule_for:  Seeking rule for node:")
+        self.log.debug("... NODE:")
+        self.log.debug(node_coord.node)
+        self.log.debug("... PARENT:")
+        self.log.debug(node_coord.parent)
+        self.log.debug("... REF:")
+        self.log.debug(node_coord.parentref)
         return self._get_config_for(node_coord, self.rules)
 
     def _get_key_for(self, node_coord: NodeCoords) -> str:

--- a/yamlpath/yamlpath.py
+++ b/yamlpath/yamlpath.py
@@ -56,53 +56,6 @@ class YAMLPath:
         else:
             self.original = yaml_path
 
-    @classmethod
-    def _stringify_yamlpath_segments(
-        cls, segments: Deque[PathSegment], seperator: PathSeperators
-    ) -> str:
-        """Stringify segments of a YAMLPath."""
-        # The following import must not occur at the toplevel because doing so
-        # causes a cyclic dependency error.  The import must occur only when
-        # this method is invoked.
-        # pylint: disable=import-outside-toplevel
-        from yamlpath.func import ensure_escaped
-
-        pathsep: str = str(seperator)
-        add_sep: bool = False
-        ppath: str = ""
-
-        # FSLASH seperator requires a path starting with a /
-        if seperator is PathSeperators.FSLASH:
-            ppath = pathsep
-
-        for (segment_type, segment_attrs) in segments:
-            if segment_type == PathSegmentTypes.KEY:
-                if add_sep:
-                    ppath += pathsep
-
-                # Replace a subset of special characters to alert users to
-                # potentially unintentional demarcation.
-                ppath += ensure_escaped(
-                    str(segment_attrs),
-                    pathsep,
-                    '(', ')', '[', ']', '^', '$', '%', ' ', "'", '"'
-                )
-            elif segment_type == PathSegmentTypes.INDEX:
-                ppath += "[{}]".format(segment_attrs)
-            elif segment_type == PathSegmentTypes.ANCHOR:
-                if add_sep:
-                    ppath += "[&{}]".format(segment_attrs)
-                else:
-                    ppath += "&{}".format(segment_attrs)
-            elif segment_type == PathSegmentTypes.SEARCH:
-                ppath += str(segment_attrs)
-            elif segment_type == PathSegmentTypes.COLLECTOR:
-                ppath += str(segment_attrs)
-
-            add_sep = True
-
-        return ppath
-
     def __str__(self) -> str:
         """Get a stringified version of this object."""
         if self._stringified:
@@ -122,7 +75,14 @@ class YAMLPath:
         return len(self.escaped)
 
     def __eq__(self, other: object) -> bool:
-        """Indicate equivalence of two YAMLPaths."""
+        """
+        Indicate equivalence of two YAMLPaths.
+
+        Parameters:
+        1. other (object) The other YAMLPath to compare against.
+
+        Returns:  (bool) true = Both are identical; false, otherwise
+        """
         if not isinstance(other, (YAMLPath, str)):
             return False
 
@@ -141,7 +101,16 @@ class YAMLPath:
         return not self == other
 
     def append(self, segment: str) -> "YAMLPath":
-        """Append a new segment to this YAML Path (without seperator)."""
+        """
+        Append a new segment to this YAML Path.
+
+        Parameters:
+        1. segment (str) The new -- pre-escaped -- segment to append to this
+           YAML Path.  Do NOT include any seperator with this value; it will be
+           added for you.
+
+        Returns:  (YAMLPath) The adjusted YAMLPath
+        """
         seperator = (
             PathSeperators.FSLASH
             if self.seperator is PathSeperators.AUTO
@@ -670,14 +639,61 @@ class YAMLPath:
         return path_segments
 
     @classmethod
-    def strip_path_prefix(cls, prefix: "YAMLPath",
-                          path: "YAMLPath") -> "YAMLPath":
+    def _stringify_yamlpath_segments(
+        cls, segments: Deque[PathSegment], seperator: PathSeperators
+    ) -> str:
+        """Stringify segments of a YAMLPath."""
+        # The following import must not occur at the toplevel because doing so
+        # causes a cyclic dependency error.  The import must occur only when
+        # this method is invoked.
+        # pylint: disable=import-outside-toplevel
+        from yamlpath.func import ensure_escaped
+
+        pathsep: str = str(seperator)
+        add_sep: bool = False
+        ppath: str = ""
+
+        # FSLASH seperator requires a path starting with a /
+        if seperator is PathSeperators.FSLASH:
+            ppath = pathsep
+
+        for (segment_type, segment_attrs) in segments:
+            if segment_type == PathSegmentTypes.KEY:
+                if add_sep:
+                    ppath += pathsep
+
+                # Replace a subset of special characters to alert users to
+                # potentially unintentional demarcation.
+                ppath += ensure_escaped(
+                    str(segment_attrs),
+                    pathsep,
+                    '(', ')', '[', ']', '^', '$', '%', ' ', "'", '"'
+                )
+            elif segment_type == PathSegmentTypes.INDEX:
+                ppath += "[{}]".format(segment_attrs)
+            elif segment_type == PathSegmentTypes.ANCHOR:
+                if add_sep:
+                    ppath += "[&{}]".format(segment_attrs)
+                else:
+                    ppath += "&{}".format(segment_attrs)
+            elif segment_type == PathSegmentTypes.SEARCH:
+                ppath += str(segment_attrs)
+            elif segment_type == PathSegmentTypes.COLLECTOR:
+                ppath += str(segment_attrs)
+
+            add_sep = True
+
+        return ppath
+
+    @classmethod
+    def strip_path_prefix(cls, path: "YAMLPath",
+                          prefix: "YAMLPath") -> "YAMLPath":
         """
         Remove a prefix from a YAML Path.
 
         Parameters:
-        1. prefix (YAMLPath) The prefix to remove (except "/").
-        2. path (YAMLPath) The path from which to remove the prefix.
+        1. path (YAMLPath) The path from which to remove the prefix.
+        2. prefix (YAMLPath) The prefix to remove (except "/").
 
         Returns:  (YAMLPath) The trimmed YAML Path.
         """


### PR DESCRIPTION
Enhancements:
* In the INI file's [rules] section, different merge rules can now be applied
  to specific parts -- no matter how deeply nested -- of the same Hash
  structure.

Bug Fixes:
* The 3rd-party Python INI file parser had no way of differentiating between
  the key and value of a YAML Path entry containing an = sign in its key, like
  "/path[.=name]/key = left".  This update reconstitutes such lines and
  correctly parses an affected YAML Path from the merge rule.

The yaml-merge command now reports version 0.0.3 to reflect these changes.
