### PR TITLE
Feature/search with star

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -42,10 +42,11 @@ Enhancements:
   ```
 * Because any document to yaml-merge can be a multi-document, it no longer
   requires at least 2 YAML_FILEs be supplied on the command-line.  If users
-  pass only a single file or stream, its content will merely be written out
-  without any merging into it.  This can be useful for trivially converting any
-  file from YAML to JSON or JSON to YAML, like `yaml-merge -D json file.yaml`
-  or `yaml-merge -D yaml file.json`.
+  pass only a single file or stream that is not a multi-document file, its
+  content will merely be written out without any merging into it.  This can be
+  useful for trivially converting any file from YAML to JSON or JSON to YAML,
+  like `yaml-merge -D json file.yaml` or `yaml-merge -D yaml file.json`.
+* The `yaml-set` command-line tool can now write changes to empty files.
 
 Bug Fixes:
 * Collectors were breaking search nodes with Regular Expressions, making it

--- a/CHANGES
+++ b/CHANGES
@@ -7,10 +7,10 @@ Enhancements:
   expands results from Collectors, effectively breaking them out from an Array-
   per-line to one-Scalar-per-line.  If you place this inside a Collector, the
   results will still be collected into an Array.
-* The * character now also serves as a wildcard character for key-names and
-  Array value comparisons, converting the segment to a Search.  For example, a
-  YAML Path like `abc.d*` becomes `abc[.^d]`, `abc.*f` becomes `abc[.$f]`, and
-  `abc.*e*` becomes `abc[.=~/^.*e.*$/], and so on.
+* The * character now also serves as a wildcard character for key-names, Hash
+  values, and Array value comparisons, converting the segment to a Search.  For
+  example, a YAML Path like `abc.d*` becomes `abc[.^d]`, `abc.*f` becomes
+  `abc[.$f]`, and `abc.*e*` becomes `abc[.=~/^.*e.*$/], and so on.
 * Added a new YAML Path Segment Type:  **
   This new type is a "Traversal" segment which causes YAML Path operations to
   deeply traverse the document from that point.  When there are no further
@@ -23,7 +23,8 @@ Enhancements:
   with --nostdin|-S.  This enables, for example, piping into these commands
   without being forced to specify the - pseudo-file as an argument to them.
 * The yaml-merge command now enables users to force the merged document to be
-  written out as YAML, JSON, or whatever type the first document is (AUTO).
+  written out as YAML, JSON via a new --document-format (-D) command-line
+  argument.  When unset, the format will be that of the first document (AUTO).
 * The yaml-merge command now accepts multi-document YAML files, created when
   the YAML standard-specified End-of-Document, Start-of-Document marker pair
   (...<EOL> followed by ---<EOL>) is present, like:
@@ -45,8 +46,25 @@ Enhancements:
   pass only a single file or stream that is not a multi-document file, its
   content will merely be written out without any merging into it.  This can be
   useful for trivially converting any file from YAML to JSON or JSON to YAML,
-  like `yaml-merge -D json file.yaml` or `yaml-merge -D yaml file.json`.
-* The `yaml-set` command-line tool can now write changes to empty files.
+  like `yaml-merge --document-format=json file.yaml` or
+  `yaml-merge --document-format=yaml file.json`.
+* The `yaml-set` command-line tool can now write changes to minimally-viable
+  files, enabling users to build up new data files from scratch.  The file must
+  exist and have some minimum structure, depending on document type.  For
+  example:
+  A minimally-viable YAML file:
+  ```yaml
+  ---
+  # The triple-dash is required.
+  ```
+  Two versions of a minimally-viable JSON file:
+  ```json
+  {}
+  ```
+  or:
+  ```json
+  []
+  ```
 
 Bug Fixes:
 * Collectors were breaking search nodes with Regular Expressions, making it

--- a/CHANGES
+++ b/CHANGES
@@ -40,6 +40,11 @@ Enhancements:
   {"document": 1}
   {"document": 2}
   ```
+* Because any document to yaml-merge can be a multi-document, it no longer
+  requires at least 2 YAML_FILEs be supplied on the command-line.  If users
+  pass only a single file or stream, its content will merely be written out
+  without any merging into it.  This can be useful for trivially converting
+  YAML to JSON or JSON to YAML.
 
 Bug Fixes:
 * Collectors were breaking search nodes with Regular Expressions, making it
@@ -59,6 +64,9 @@ API Changes:
   Because these were all protected methods and the affected parameters were
   optional anyway, this is not deemed a breaking change; no one should have
   been directly calling them.
+* The get_yaml_editor function now supports several keyword arguments which
+  provide for some customization of the returned ruamel.yaml.YAML instance.
+  See its documentation for details.
 
 To reflect these changes:
 * yaml-get is now version 1.2.0

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,23 @@
+2.5.0:
+Enhancements:
+* Added a new YAML Path Segment Type:  *
+  This is identical to a Search segment where the search term is `[.!=""]`.
+  This translates to "match every Hash key for which its name is not empty and
+  every Array element which is not empty".  This operator also vertically
+  expands results from Collectors, effectively breaking them out from an Array-
+  per-line to one-Scalar-per-line.  If you place this inside a Collector, the
+  results will still be collected.
+* Added a new YAML Path Segment Type:  **
+  This new type is a "Traversal" segment which causes YAML Path operations to
+  deeply traverse the document from that point.  When there are no further
+  segments in the YAML Path, every leaf node (Scalar value) is matched.  When
+  the YAML Path has at least one further segment, it must match nodes to return
+  or none are returned.  Results can be collected.
+
+Bug Fixes:
+* Collectors were breaking search nodes with Regular Expressions, making it
+  impossible for collected searches to return expected matches.
+
 2.4.3:
 Bug Fixes:
 * Array-of-Hashes were not being detected for the purpose of applying merge

--- a/CHANGES
+++ b/CHANGES
@@ -36,6 +36,11 @@ API Changes:
   optional anyway, this is not deemed a breaking change; no one should have
   been directly calling them.
 
+To reflect these changes:
+* yaml-get is now version 1.2.0
+* yaml-set is now version 1.1.0
+* yaml-merge is now version 0.1.0
+
 2.4.3:
 Bug Fixes:
 * Array-of-Hashes were not being detected for the purpose of applying merge

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,4 @@
-2.5.0:
+3.0.0:
 Enhancements:
 * Added a new YAML Path Segment Type:  *
   This is identical to a Search segment where the search term is `[.!=""]`.
@@ -58,7 +58,7 @@ Bug Fixes:
   a YAML document start mark (---) and then a hybrid JSON/YAML result rather
   than valid JSON.
 
-API Changes:
+Non-Breaking API Changes:
 * The various protected _get_* methods of Processor were changed to reduce the
   number of positional parameters while also allowing for new special-use
   parameters for future changes.  The formerly optional positional `parent` and
@@ -68,7 +68,28 @@ API Changes:
   been directly calling them.
 * The get_yaml_editor function now supports several keyword arguments which
   provide for some customization of the returned ruamel.yaml.YAML instance.
-  See its documentation for details.
+  See its documentation for details.  This is a non-breaking change as the
+  defaults for each new keyword argument set the behavior identical to what it
+  was before this change.
+* The get_yaml_data function now returns False rather than None when there is
+  an issue attempting to load data.  This is because an empty-but-viable
+  document correctly returns None but there is no valid YAML or JSON document
+  which can be comprised only of a Scalar Boolean.  This is a non-breaking
+  change because None and False are equivalent for code like:
+  ```python
+  data = get_yaml_data(get_yaml_editor(), ConsoleLogger(), "file.yaml")
+  if not data:
+    print("No data")
+  ```
+  However, you can now differentiate between "No data" and "Invalid document"
+  like so:
+  ```python
+  data = get_yaml_data(get_yaml_editor(), ConsoleLogger(), "file.yaml")
+  if data is None:
+    print("No data")
+  elif not data:
+    print("Invalid document")
+  ```
 
 To reflect these changes:
 * yaml-get is now version 1.2.0

--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,9 @@ Enhancements:
   segments in the YAML Path, every leaf node (Scalar value) is matched.  When
   the YAML Path has at least one further segment, it must match nodes to return
   or none are returned.  Results can be collected.
+* The yaml-merge and yaml-get command-line tools now treat the - pseudo-file as
+  optional.  If the terminal is not a TTY, any waiting (piped or
+  read-from-file) data is read as a YAML/Compatible document.
 
 Bug Fixes:
 * Collectors were breaking search nodes with Regular Expressions, making it

--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,8 @@ Enhancements:
 Bug Fixes:
 * Collectors were breaking search nodes with Regular Expressions, making it
   impossible for collected searches to return expected matches.
+* Fixed the Known Issue which was logged at version 2.4.0; setting override
+  key-value pairs now correctly update the DOM for aliases.
 
 API Changes:
 * The various protected _get_* methods of Processor were changed to reduce the

--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,10 @@ Enhancements:
   expands results from Collectors, effectively breaking them out from an Array-
   per-line to one-Scalar-per-line.  If you place this inside a Collector, the
   results will still be collected.
+* The * character now also serves as a wildcard character for key-names and
+  Array value comparisons, converting the segment to a Search.  For example, a
+  YAML Path like `abc.d*` becomes `abc[.^d]`, `abc.*f` becomes `abc[.$f]`, and
+  `abc.*e*` becomes `abc[.=~/^.*e.*$/]
 * Added a new YAML Path Segment Type:  **
   This new type is a "Traversal" segment which causes YAML Path operations to
   deeply traverse the document from that point.  When there are no further

--- a/CHANGES
+++ b/CHANGES
@@ -20,12 +20,22 @@ Enhancements:
 * The yaml-merge and yaml-get command-line tools now treat the - pseudo-file as
   implicit when NOT specified AND the session is non-TTY.  This can be blocked
   with --nostdin|-S.
+* The yaml-merge command now accepts the YAML standard-specified
+  End-of-Document, Start-of-Document marker pair (...<EOL> followed by
+  ---<EOL>) to enable STDIN to receive multiple YAML documents.  There is no
+  definitive equivalent for JSON other than writing a custom JSON parser which
+  can handle multiple documents in a single stream, so multi-JSON documents in
+  a single STDIN stream are not yet supported.
 
 Bug Fixes:
 * Collectors were breaking search nodes with Regular Expressions, making it
   impossible for collected searches to return expected matches.
 * Fixed the Known Issue which was logged at version 2.4.0; setting override
   key-value pairs now correctly update the DOM for aliases.
+* When the left-most document is JSON and there are no YAML-specific extensions
+  in the resulting document (like Anchors), yaml-merge will write out JSON
+  results rather than hybrid JSON/YAML; otherwise, fully block-form YAML will
+  be written.
 
 API Changes:
 * The various protected _get_* methods of Processor were changed to reduce the

--- a/CHANGES
+++ b/CHANGES
@@ -72,9 +72,9 @@ Bug Fixes:
 * Fixed the Known Issue which was logged at version 2.4.0; setting values which
   override aliased key-value pairs now correctly adds the new key-value pair to
   the DOM.
-* When the left-most document was JSON, yaml-merge would improperly write out
-  a YAML document start mark (---) and then a hybrid JSON/YAML result rather
-  than valid JSON.
+* When the left-most document was JSON, yaml-merge and yaml-set would both
+  improperly write out a YAML document start mark (---) and then a hybrid
+  JSON/YAML result rather than valid JSON.
 
 Non-Breaking API Changes:
 * The various protected _get_* methods of Processor were changed to reduce the

--- a/CHANGES
+++ b/CHANGES
@@ -43,8 +43,9 @@ Enhancements:
 * Because any document to yaml-merge can be a multi-document, it no longer
   requires at least 2 YAML_FILEs be supplied on the command-line.  If users
   pass only a single file or stream, its content will merely be written out
-  without any merging into it.  This can be useful for trivially converting
-  YAML to JSON or JSON to YAML.
+  without any merging into it.  This can be useful for trivially converting any
+  file from YAML to JSON or JSON to YAML, like `yaml-merge -D json file.yaml`
+  or `yaml-merge -D yaml file.json`.
 
 Bug Fixes:
 * Collectors were breaking search nodes with Regular Expressions, making it

--- a/CHANGES
+++ b/CHANGES
@@ -6,20 +6,24 @@ Enhancements:
   every Array element which is not empty".  This operator also vertically
   expands results from Collectors, effectively breaking them out from an Array-
   per-line to one-Scalar-per-line.  If you place this inside a Collector, the
-  results will still be collected.
+  results will still be collected into an Array.
 * The * character now also serves as a wildcard character for key-names and
   Array value comparisons, converting the segment to a Search.  For example, a
   YAML Path like `abc.d*` becomes `abc[.^d]`, `abc.*f` becomes `abc[.$f]`, and
-  `abc.*e*` becomes `abc[.=~/^.*e.*$/]
+  `abc.*e*` becomes `abc[.=~/^.*e.*$/], and so on.
 * Added a new YAML Path Segment Type:  **
   This new type is a "Traversal" segment which causes YAML Path operations to
   deeply traverse the document from that point.  When there are no further
   segments in the YAML Path, every leaf node (Scalar value) is matched.  When
-  the YAML Path has at least one further segment, it must match nodes to return
-  or none are returned.  Results can be collected.
+  the YAML Path has at least one further segment, it (and all further segments)
+  must match subsequent nodes (anywhere deeper than that point in the document)
+  or none are matched. Results can be collected.
 * The yaml-merge and yaml-get command-line tools now treat the - pseudo-file as
   implicit when NOT specified AND the session is non-TTY.  This can be blocked
-  with --nostdin|-S.
+  with --nostdin|-S.  This enables, for example, piping into these commands
+  without being forced to specify the - pseudo-file as an argument to them.
+* The yaml-merge command now enables users to force the merged document to be
+  written out as YAML, JSON, or whatever type the first document is (AUTO).
 * The yaml-merge command now accepts the YAML standard-specified
   End-of-Document, Start-of-Document marker pair (...<EOL> followed by
   ---<EOL>) to enable STDIN to receive multiple YAML documents.  There is no
@@ -32,10 +36,9 @@ Bug Fixes:
   impossible for collected searches to return expected matches.
 * Fixed the Known Issue which was logged at version 2.4.0; setting override
   key-value pairs now correctly update the DOM for aliases.
-* When the left-most document is JSON and there are no YAML-specific extensions
-  in the resulting document (like Anchors), yaml-merge will write out JSON
-  results rather than hybrid JSON/YAML; otherwise, fully block-form YAML will
-  be written.
+* When the left-most document was JSON, yaml-merge would improperly write out
+  a YAML document start mark (---) and then a hybrid JSON/YAML result rather
+  than valid JSON.
 
 API Changes:
 * The various protected _get_* methods of Processor were changed to reduce the

--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,15 @@ Bug Fixes:
 * Collectors were breaking search nodes with Regular Expressions, making it
   impossible for collected searches to return expected matches.
 
+API Changes:
+* The various protected _get_* methods of Processor were changed to reduce the
+  number of positional parameters while also allowing for new special-use
+  parameters for future changes.  The formerly optional positional `parent` and
+  `parentref` parameters are now optional keyword arguments by the same names.
+  Because these were all protected methods and the affected parameters were
+  optional anyway, this is not deemed a breaking change; no one should have
+  been directly calling them.
+
 2.4.3:
 Bug Fixes:
 * Array-of-Hashes were not being detected for the purpose of applying merge

--- a/CHANGES
+++ b/CHANGES
@@ -92,9 +92,11 @@ Non-Breaking API Changes:
   ```
 
 To reflect these changes:
+* eyaml-rotate-keys is now version 1.0.4
 * yaml-get is now version 1.2.0
-* yaml-set is now version 1.1.0
 * yaml-merge is now version 0.1.0
+* yaml-paths is now version 0.2.1
+* yaml-set is now version 1.1.0
 
 2.4.3:
 Bug Fixes:

--- a/CHANGES
+++ b/CHANGES
@@ -24,12 +24,22 @@ Enhancements:
   without being forced to specify the - pseudo-file as an argument to them.
 * The yaml-merge command now enables users to force the merged document to be
   written out as YAML, JSON, or whatever type the first document is (AUTO).
-* The yaml-merge command now accepts the YAML standard-specified
-  End-of-Document, Start-of-Document marker pair (...<EOL> followed by
-  ---<EOL>) to enable STDIN to receive multiple YAML documents.  There is no
-  definitive equivalent for JSON other than writing a custom JSON parser which
-  can handle multiple documents in a single stream, so multi-JSON documents in
-  a single STDIN stream are not yet supported.
+* The yaml-merge command now accepts multi-document YAML files, created when
+  the YAML standard-specified End-of-Document, Start-of-Document marker pair
+  (...<EOL> followed by ---<EOL>) is present, like:
+  ```yaml
+  ---
+  document: 1
+  ...
+  ---
+  document: 2
+  ```
+* The yaml-merge command now accepts multi-document JSON files, created when
+  there are multiple root-level entities, like:
+  ```json
+  {"document": 1}
+  {"document": 2}
+  ```
 
 Bug Fixes:
 * Collectors were breaking search nodes with Regular Expressions, making it

--- a/CHANGES
+++ b/CHANGES
@@ -44,8 +44,9 @@ Enhancements:
 Bug Fixes:
 * Collectors were breaking search nodes with Regular Expressions, making it
   impossible for collected searches to return expected matches.
-* Fixed the Known Issue which was logged at version 2.4.0; setting override
-  key-value pairs now correctly update the DOM for aliases.
+* Fixed the Known Issue which was logged at version 2.4.0; setting values which
+  override aliased key-value pairs now correctly adds the new key-value pair to
+  the DOM.
 * When the left-most document was JSON, yaml-merge would improperly write out
   a YAML document start mark (---) and then a hybrid JSON/YAML result rather
   than valid JSON.

--- a/CHANGES
+++ b/CHANGES
@@ -18,8 +18,8 @@ Enhancements:
   the YAML Path has at least one further segment, it must match nodes to return
   or none are returned.  Results can be collected.
 * The yaml-merge and yaml-get command-line tools now treat the - pseudo-file as
-  optional.  If the terminal is not a TTY, any waiting (piped or
-  read-from-file) data is read as a YAML/Compatible document.
+  implicit when NOT specified AND the session is non-TTY.  This can be blocked
+  with --nostdin|-S.
 
 Bug Fixes:
 * Collectors were breaking search nodes with Regular Expressions, making it

--- a/README.md
+++ b/README.md
@@ -391,7 +391,7 @@ https://github.com/wwkimball/yamlpath.
 usage: yaml-merge [-h] [-V] [-c CONFIG] [-a {stop,left,right,rename}]
                   [-A {all,left,right,unique}] [-H {deep,left,right}]
                   [-O {all,deep,left,right,unique}] [-m YAML_PATH] [-o OUTPUT]
-                  [-d | -v | -q]
+                  [-S] [-d | -v | -q]
                   YAML_FILE [YAML_FILE ...]
 
 Merges two or more YAML/Compatible files together.
@@ -431,6 +431,8 @@ optional arguments:
   -o OUTPUT, --output OUTPUT
                         Write the merged result to the indicated file (or
                         STDOUT when unset)
+  -S, --nostdin         Do not implicitly read from STDIN, even when there are
+                        no - pseudo-files in YAML_FILEs with a non-TTY session
   -d, --debug           output debugging details
   -v, --verbose         increase output verbosity
   -q, --quiet           suppress all output except errors (implied when
@@ -451,7 +453,12 @@ optional arguments:
 
             The left-to-right order of YAML_FILEs is significant.  Except
             when this behavior is deliberately altered by your options, data
-            from files on the right overrides data in files to their left.
+            from files on the right overrides data in files to their left.  At
+            least two YAML_FILEs are required.  Only one may be the -
+            pseudo-file.  When only one YAML_FILE is provided, it cannot be the
+            - pseudo-file and in this special-case - will be inferred as the
+            second YAML_FILE as long as you are running this program without a
+            TTY (unless you set --nostdin|-S).
             For more information about YAML Paths, please visit
             https://github.com/wwkimball/yamlpath.
 ```

--- a/README.md
+++ b/README.md
@@ -1003,9 +1003,10 @@ except MergeException as mex:
 except YAMLPathException as yex:
     log.critical(yex, 130)
 
-# At this point, merger.data is the merged result; do what you will with it.
-# When you are ready to dump (write) out the merged data, you must prepare the
-# document and your ruamel.yaml.YAML instance -- usually obtained from
-# func.get_yaml_editor() -- like this:
+# At this point, merger.data is the merged result; do what you will with it,
+# including merging more data into it.  When you are ready to dump (write)
+# out the merged data, you must prepare the document and your
+# ruamel.yaml.YAML instance -- usually obtained from func.get_yaml_editor()
+# -- like this:
 merger.prepare_for_dump(my_yaml_editor)
 ```

--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ EYAML options:
 For more information about YAML Paths, please visit
 https://github.com/wwkimball/yamlpath.
 ```
+
 * [yaml-merge](yamlpath/commands/yaml_merge.py)
 
 ```text

--- a/README.md
+++ b/README.md
@@ -344,9 +344,9 @@ when -b/--backup is specified).
 
 ```text
 usage: yaml-get [-h] [-V] -p YAML_PATH
-                [-t ['.', '/', 'auto', 'dot', 'fslash']] [-x EYAML]
+                [-t ['.', '/', 'auto', 'dot', 'fslash']] [-S] [-x EYAML]
                 [-r PRIVATEKEY] [-u PUBLICKEY] [-d | -v | -q]
-                YAML_FILE
+                [YAML_FILE]
 
 Retrieves one or more values from a YAML file at a specified YAML Path. Output
 is printed to STDOUT, one line per result. When a result is a complex data-
@@ -354,7 +354,8 @@ type (Array or Hash), a JSON dump is produced to represent it. EYAML can be
 employed to decrypt the values.
 
 positional arguments:
-  YAML_FILE             the YAML file to query; use - to read from STDIN
+  YAML_FILE             the YAML file to query; use - to read from STDIN or
+                        leave empty and send content via a non-TTY session
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -362,6 +363,8 @@ optional arguments:
   -t ['.', '/', 'auto', 'dot', 'fslash'], --pathsep ['.', '/', 'auto', 'dot', 'fslash']
                         indicate which YAML Path seperator to use when
                         rendering results; default=dot
+  -S, --nostdin         Do not implicitly read from STDIN, even when YAML_FILE
+                        is not set and the session is non-TTY
   -d, --debug           output debugging details
   -v, --verbose         increase output verbosity
   -q, --quiet           suppress all output except errors

--- a/README.md
+++ b/README.md
@@ -988,12 +988,7 @@ from yamlpath.merger.exceptions import MergeException
 from yamlpath.merger import Merger, MergerConfig
 
 # Obtain or build the lhs_data and rhs_data objects using get_yaml_data or
-# equivalent.  Once loaded, all comments must be deleted lest the merged result
-# look quite odd; there is no sensible way to merge freetext comments or white-
-# space within text documents lacking a predictable, direct differential
-# relationship.
-Merger.delete_all_comments(lhs_data)
-Merger.delete_all_comments(rhs_data)
+# equivalent.
 
 # You'll still need to supply a logger and some arguments used by the merge
 # engine.  For purely default behavior, you could create args as a bare
@@ -1009,4 +1004,8 @@ except YAMLPathException as yex:
     log.critical(yex, 130)
 
 # At this point, merger.data is the merged result; do what you will with it.
+# When you are ready to dump (write) out the merged data, you must prepare the
+# document and your ruamel.yaml.YAML instance -- usually obtained from
+# func.get_yaml_editor() -- like this:
+merger.prepare_for_dump(my_yaml_editor)
 ```

--- a/tests/test_commands_yaml_get.py
+++ b/tests/test_commands_yaml_get.py
@@ -8,14 +8,14 @@ class Test_yaml_get():
     command = "yaml-get"
 
     def test_no_options(self, script_runner):
-        result = script_runner.run(self.command)
+        result = script_runner.run(self.command, "--nostdin")
         assert not result.success, result.stderr
-        assert "the following arguments are required: -p/--query, YAML_FILE" in result.stderr
+        assert "the following arguments are required: -p/--query" in result.stderr
 
     def test_no_input_file(self, script_runner):
-        result = script_runner.run(self.command, "--query='/test'")
+        result = script_runner.run(self.command, "--nostdin", "--query='/test'")
         assert not result.success, result.stderr
-        assert "the following arguments are required: YAML_FILE" in result.stderr
+        assert "YAML_FILE must be set or be read from STDIN" in result.stderr
 
     def test_bad_input_file(self, script_runner):
         result = script_runner.run(self.command, "--query='/test'", "no-such-file")

--- a/tests/test_commands_yaml_get.py
+++ b/tests/test_commands_yaml_get.py
@@ -109,3 +109,26 @@ class Test_yaml_get():
         result = script_runner.run(self.command, "--query=aliases", yaml_file)
         assert result.success, result.stderr
         assert '["Plain scalar string"]' in result.stdout
+
+    def test_query_doc_from_stdin(
+        self, script_runner, tmp_path_factory
+    ):
+        import subprocess
+
+        yaml_file = """---
+hash:
+  lhs_exclusive: LHS exclusive
+  merge_target: LHS original value
+"""
+
+        result = subprocess.run(
+            [self.command
+            , "--query=/hash/lhs_exclusive"
+            , "-"]
+            , stdout=subprocess.PIPE
+            , input=yaml_file
+            , universal_newlines=True
+        )
+
+        assert 0 == result.returncode, result.stderr
+        assert "LHS exclusive\n" == result.stdout

--- a/tests/test_commands_yaml_merge.py
+++ b/tests/test_commands_yaml_merge.py
@@ -110,7 +110,7 @@ hash:
         assert result.success, result.stderr
         assert merged_yaml_content == result.stdout
 
-    def test_merge_two_happy_files_to_file(self, script_runner, tmp_path, tmp_path_factory):
+    def test_merge_two_happy_yaml_files_to_file(self, script_runner, tmp_path, tmp_path_factory):
         lhs_file = create_temp_yaml_file(tmp_path_factory, """---
 hash:
   lhs_exclusive: LHS exclusive
@@ -128,7 +128,7 @@ hash:
   merge_target: RHS override value
 """
 
-        output_dir = tmp_path / "test_merge_two_files"
+        output_dir = tmp_path / "test_merge_two_happy_yaml_files_to_file"
         output_dir.mkdir()
         output_file = output_dir / "output.yaml"
 
@@ -145,6 +145,162 @@ hash:
             , "--output={}".format(output_file)
             , lhs_file
             , rhs_file)
+        assert result.success, result.stderr
+
+        with open(output_file, 'r') as fhnd:
+            filedat = fhnd.read()
+        assert merged_yaml_content == filedat
+
+    def test_merge_two_happy_multidoc_yaml_files_to_file(self, script_runner, tmp_path, tmp_path_factory):
+        lhs_file = create_temp_yaml_file(tmp_path_factory, """---
+hash:
+  lhs_exclusive: LHS exclusive
+  merge_target: LHS original value
+...
+---
+hash:
+  lhs2_exclusive: LHS2 exclusive
+  merge2_target: LHS2 original value
+""")
+        rhs_file = create_temp_yaml_file(tmp_path_factory, """---
+hash:
+  rhs_exclusive: RHS exclusive
+  merge_target: RHS override value
+...
+---
+hash:
+  rhs2_exclusive: RHS2 exclusive
+  merge_target: RHS2 override value
+  merge2_target: RHS2 2nd override value
+""")
+        merged_yaml_content = """---
+hash:
+  lhs_exclusive: LHS exclusive
+  rhs2_exclusive: RHS2 exclusive
+  rhs_exclusive: RHS exclusive
+  merge_target: RHS2 override value
+  lhs2_exclusive: LHS2 exclusive
+  merge2_target: RHS2 2nd override value
+"""
+
+        output_dir = tmp_path / "test_merge_two_happy_multidoc_yaml_files_to_file"
+        output_dir.mkdir()
+        output_file = output_dir / "output.yaml"
+
+        # DEBUG
+        # print("LHS File:  {}".format(lhs_file))
+        # print("RHS File:  {}".format(rhs_file))
+        # print("Output File:  {}".format(output_file))
+        # print("Expected Output:")
+        # print(merged_yaml_content)
+
+        result = script_runner.run(
+            self.command
+            , "--nostdin"
+            , "--output={}".format(output_file)
+            , lhs_file
+            , rhs_file)
+        assert result.success, result.stderr
+
+        with open(output_file, 'r') as fhnd:
+            filedat = fhnd.read()
+        assert merged_yaml_content == filedat
+
+    def test_merge_two_happy_json_files_to_file(self, script_runner, tmp_path, tmp_path_factory):
+        lhs_file = create_temp_yaml_file(tmp_path_factory, """{
+  "hash": {
+      "lhs_exclusive": "LHS exclusive",
+      "merge_target": "LHS original value"
+  }
+}
+""")
+        rhs_file = create_temp_yaml_file(tmp_path_factory, """{
+  "hash": {
+      "rhs_exclusive": "RHS exclusive",
+      "merge_target": "RHS override value"
+  }
+}
+""")
+        merged_yaml_content = """{"hash": {"lhs_exclusive": "LHS exclusive", "rhs_exclusive": "RHS exclusive", "merge_target": "RHS override value"}}
+"""
+
+        output_dir = tmp_path / "test_merge_two_happy_json_files_to_file"
+        output_dir.mkdir()
+        output_file = output_dir / "output.yaml"
+
+        # DEBUG
+        # print("LHS File:  {}".format(lhs_file))
+        # print("RHS File:  {}".format(rhs_file))
+        # print("Output File:  {}".format(output_file))
+        # print("Expected Output:")
+        # print(merged_yaml_content)
+
+        result = script_runner.run(
+            self.command
+            , "--nostdin"
+            , "--output={}".format(output_file)
+            , lhs_file
+            , rhs_file)
+        assert result.success, result.stderr
+
+        with open(output_file, 'r') as fhnd:
+            filedat = fhnd.read()
+        assert merged_yaml_content == filedat
+
+    def test_convert_yaml_to_json_file(self, script_runner, tmp_path, tmp_path_factory):
+        lhs_file = create_temp_yaml_file(tmp_path_factory, """---
+hash:
+  lhs_exclusive: LHS exclusive
+  merge_target: LHS original value
+""")
+        merged_yaml_content = """{"hash": {"lhs_exclusive": "LHS exclusive", "merge_target": "LHS original value"}}"""
+
+        output_dir = tmp_path / "test_convert_yaml_to_json_file"
+        output_dir.mkdir()
+        output_file = output_dir / "output.yaml"
+
+        # DEBUG
+        # print("LHS File:  {}".format(lhs_file))
+        # print("Output File:  {}".format(output_file))
+        # print("Expected Output:")
+        # print(merged_yaml_content)
+
+        result = script_runner.run(
+            self.command
+            , "--nostdin"
+            , "--document-format=json"
+            , "--output={}".format(output_file)
+            , lhs_file)
+        assert result.success, result.stderr
+
+        with open(output_file, 'r') as fhnd:
+            filedat = fhnd.read()
+        assert merged_yaml_content == filedat
+
+    def test_convert_json_to_yaml_file(self, script_runner, tmp_path, tmp_path_factory):
+        lhs_file = create_temp_yaml_file(tmp_path_factory, """{"hash": {"lhs_exclusive": "LHS exclusive", "merge_target": "LHS original value"}}""")
+        merged_yaml_content = """---
+"hash":
+  "lhs_exclusive": "LHS exclusive"
+  "merge_target": "LHS original value"
+"""
+
+        output_dir = tmp_path / "test_convert_yaml_to_json_file"
+        output_dir.mkdir()
+        output_file = output_dir / "output.yaml"
+
+        # DEBUG
+        # print("LHS File:  {}".format(lhs_file))
+        # print("Output File:  {}".format(output_file))
+        # print("Expected Output:")
+        # print(merged_yaml_content)
+
+        result = script_runner.run(
+            self.command
+            , "--nostdin"
+            , "--document-format=yaml"
+            , "--output={}".format(output_file)
+            , lhs_file)
         assert result.success, result.stderr
 
         with open(output_file, 'r') as fhnd:
@@ -168,7 +324,29 @@ hash:
             , rhs_file)
         assert not result.success, result.stderr
 
-    def test_merge_from_stdin_to_stdout(
+    def test_bad_multidoc_rhs_input_file(self, script_runner, tmp_path_factory):
+        lhs_file = create_temp_yaml_file(tmp_path_factory, """---
+hash:
+  lhs_exclusive: LHS exclusive
+  merge_target: LHS original value
+""")
+        rhs_file = create_temp_yaml_file(tmp_path_factory, """---
+hash:
+  rhs_exclusive: RHS exclusive
+  merge_target: RHS override value
+...
+---
+- one
+- two
+""")
+
+        result = script_runner.run(
+            self.command
+            , lhs_file
+            , rhs_file)
+        assert not result.success, result.stderr
+
+    def test_merge_explicit_from_stdin_to_stdout(
         self, script_runner, tmp_path_factory
     ):
         import subprocess
@@ -191,6 +369,80 @@ hash:
             [self.command
             , lhs_file
             , "-"]
+            , stdout=subprocess.PIPE
+            , input=rhs_content
+            , universal_newlines=True
+        )
+
+        # DEBUG
+        # print("Expected:")
+        # print(merged_yaml_content)
+        # print("Got:")
+        # print(result.stdout)
+
+        assert 0 == result.returncode, result.stderr
+        assert merged_yaml_content == result.stdout
+
+    def test_merge_implicit_from_stdin_to_stdout_implicit_json(
+        self, script_runner, tmp_path_factory
+    ):
+        import subprocess
+
+        lhs_file = create_temp_yaml_file(tmp_path_factory, """{
+  "hash": {
+      "lhs_exclusive": "LHS exclusive",
+      "merge_target": "LHS original value"
+  }
+}
+""")
+        rhs_content = """{
+  "hash": {
+      "rhs_exclusive": "RHS exclusive",
+      "merge_target": "RHS override value"
+  }
+}
+"""
+        merged_yaml_content = """{"hash": {"lhs_exclusive": "LHS exclusive", "rhs_exclusive": "RHS exclusive", "merge_target": "RHS override value"}}
+"""
+
+        result = subprocess.run(
+            [self.command
+            , lhs_file]
+            , stdout=subprocess.PIPE
+            , input=rhs_content
+            , universal_newlines=True
+        )
+
+        # DEBUG
+        # print("Expected:")
+        # print(merged_yaml_content)
+        # print("Got:")
+        # print(result.stdout)
+
+        assert 0 == result.returncode, result.stderr
+        assert merged_yaml_content == result.stdout
+
+    def test_merge_implicit_from_stdin_to_stdout_explicit_json(
+        self, script_runner, tmp_path_factory
+    ):
+        import subprocess
+
+        lhs_file = create_temp_yaml_file(tmp_path_factory, """---
+hash:
+  lhs_exclusive: LHS exclusive
+  merge_target: LHS original value
+""")
+        rhs_content = """---
+hash:
+  rhs_exclusive: RHS exclusive
+  merge_target: RHS override value
+"""
+        merged_yaml_content = """{"hash": {"lhs_exclusive": "LHS exclusive", "rhs_exclusive": "RHS exclusive", "merge_target": "RHS override value"}}"""
+
+        result = subprocess.run(
+            [self.command
+            , lhs_file
+            , "--document-format=json"]
             , stdout=subprocess.PIPE
             , input=rhs_content
             , universal_newlines=True
@@ -230,3 +482,8 @@ new_key: New value
             , '-')
         assert not result.success, result.stderr
         assert "Only one YAML_FILE may be the - pseudo-file" in result.stderr
+
+    def test_yaml_syntax_error(self, script_runner, badsyntax_yaml_file, old_eyaml_keys, new_eyaml_keys):
+        result = script_runner.run(self.command, badsyntax_yaml_file)
+        assert not result.success, result.stderr
+        assert "YAML syntax error" in result.stderr

--- a/tests/test_commands_yaml_merge.py
+++ b/tests/test_commands_yaml_merge.py
@@ -8,14 +8,14 @@ class Test_commands_yaml_merge():
     command = "yaml-merge"
 
     def test_no_options(self, script_runner):
-        result = script_runner.run(self.command)
+        result = script_runner.run(self.command, "--nostdin")
         assert not result.success, result.stderr
-        assert "the following arguments are required: YAML_FILE" in result.stderr
+        assert "There must be at least one YAML_FILE" in result.stderr
 
     def test_missing_input_file_arg(self, script_runner):
         result = script_runner.run(self.command, "--nostdin", "no-file.yaml")
         assert not result.success, result.stderr
-        assert "There must be at least two YAML_FILEs" in result.stderr
+        assert "File not found" in result.stderr
 
     def test_missing_config_file(self, script_runner):
         result = script_runner.run(
@@ -46,7 +46,7 @@ key: value
             , "no-file.yaml"
             , "-")
         assert not result.success, result.stderr
-        assert "The first input file" in result.stderr
+        assert "File not found" in result.stderr
 
     def test_missing_rhs_input_file(self, script_runner, tmp_path_factory):
         lhs_file = create_temp_yaml_file(tmp_path_factory, """---

--- a/tests/test_commands_yaml_merge.py
+++ b/tests/test_commands_yaml_merge.py
@@ -13,7 +13,7 @@ class Test_commands_yaml_merge():
         assert "the following arguments are required: YAML_FILE" in result.stderr
 
     def test_missing_input_file_arg(self, script_runner):
-        result = script_runner.run(self.command, "no-file.yaml")
+        result = script_runner.run(self.command, "--nostdin", "no-file.yaml")
         assert not result.success, result.stderr
         assert "There must be at least two YAML_FILEs" in result.stderr
 
@@ -104,6 +104,7 @@ hash:
 
         result = script_runner.run(
             self.command
+            , "--nostdin"
             , lhs_file
             , rhs_file)
         assert result.success, result.stderr
@@ -140,6 +141,7 @@ hash:
 
         result = script_runner.run(
             self.command
+            , "--nostdin"
             , "--output={}".format(output_file)
             , lhs_file
             , rhs_file)
@@ -220,3 +222,11 @@ new_key: New value
             , rhs_file)
         assert not result.success, result.stderr
         assert "Unexpected use of ~ operator" in result.stderr
+
+    def test_too_many_pseudofiles(self, script_runner):
+        result = script_runner.run(
+            self.command
+            , '-'
+            , '-')
+        assert not result.success, result.stderr
+        assert "Only one YAML_FILE may be the - pseudo-file" in result.stderr

--- a/tests/test_commands_yaml_set.py
+++ b/tests/test_commands_yaml_set.py
@@ -520,3 +520,20 @@ some:
         with open(yaml_file, 'r') as fhnd:
             filedat = fhnd.read()
         assert filedat == result_content
+
+    def test_set_value_in_json_file(
+        self, script_runner, tmp_path_factory
+    ):
+        yaml_file = create_temp_yaml_file(tmp_path_factory, '{"key": "value"}')
+        result_content = '{"key": "changed"}'
+
+        result = script_runner.run(
+            self.command
+            , "--change=key"
+            , "--value=changed"
+            , yaml_file)
+        assert result.success, result.stderr
+
+        with open(yaml_file, 'r') as fhnd:
+            filedat = fhnd.read()
+        assert filedat == result_content

--- a/tests/test_commands_yaml_set.py
+++ b/tests/test_commands_yaml_set.py
@@ -499,3 +499,24 @@ aliases:
         with open(yaml_file, 'r') as fhnd:
             filedat = fhnd.read()
         assert filedat == yamlout
+
+    def test_set_value_in_empty_file(
+        self, script_runner, tmp_path_factory
+    ):
+        yaml_file = create_temp_yaml_file(tmp_path_factory, "")
+        result_content = """---
+some:
+  key:
+    to: nowhere
+"""
+
+        result = script_runner.run(
+            self.command
+            , "--change=some.key.to"
+            , "--value=nowhere"
+            , yaml_file)
+        assert result.success, result.stderr
+
+        with open(yaml_file, 'r') as fhnd:
+            filedat = fhnd.read()
+        assert filedat == result_content

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -20,6 +20,7 @@ from yamlpath.func import (
     escape_path_section,
     get_yaml_data,
     get_yaml_editor,
+    get_yaml_multidoc_data,
     make_new_node,
     wrap_type,
 )
@@ -35,20 +36,19 @@ def force_ruamel_load_keyboardinterrupt(monkeypatch):
         raise KeyboardInterrupt
 
     monkeypatch.setattr(break_class, "load", fake_load)
+    monkeypatch.setattr(break_class, "load_all", fake_load)
 
 class Test_func():
+    ###
+    # get_yaml_editor
+    ###
     def test_get_yaml_editor(self):
         assert get_yaml_editor()
 
-    def test_get_yaml_data_filenotfound_error(
-        self, capsys, quiet_logger,
-        force_ruamel_load_keyboardinterrupt
-    ):
-        yp = get_yaml_editor()
-        assert False == get_yaml_data(yp, quiet_logger, "no-such.file")
-        captured = capsys.readouterr()
-        assert -1 < captured.err.find("File not found")
 
+    ###
+    # get_yaml_data
+    ###
     def test_get_yaml_data_keyboardinterrupt_error(
         self, capsys, quiet_logger, tmp_path_factory,
         force_ruamel_load_keyboardinterrupt
@@ -61,6 +61,54 @@ class Test_func():
         assert False == get_yaml_data(yp, quiet_logger, yaml_file)
         captured = capsys.readouterr()
         assert -1 < captured.err.find("keyboard interrupt")
+
+    def test_get_yaml_data_filenotfound_error(
+        self, capsys, quiet_logger,
+        force_ruamel_load_keyboardinterrupt
+    ):
+        yp = get_yaml_editor()
+        assert False == get_yaml_data(yp, quiet_logger, "no-such.file")
+        captured = capsys.readouterr()
+        assert -1 < captured.err.find("File not found")
+
+    def test_get_yaml_data_parser_error(
+        self, capsys, quiet_logger,
+        imparsible_yaml_file
+    ):
+        yp = get_yaml_editor()
+        assert False == get_yaml_data(yp, quiet_logger, imparsible_yaml_file)
+        captured = capsys.readouterr()
+        assert -1 < captured.err.find("YAML parsing error")
+
+    def test_get_yaml_data_composition_error(
+        self, capsys, quiet_logger,
+        badcmp_yaml_file
+    ):
+        yp = get_yaml_editor()
+        assert False == get_yaml_data(yp, quiet_logger, badcmp_yaml_file)
+        captured = capsys.readouterr()
+        assert -1 < captured.err.find("YAML composition error")
+
+    def test_get_yaml_data_construction_error(
+        self, capsys, quiet_logger, tmp_path_factory
+    ):
+        yp = get_yaml_editor()
+        content = """---
+        missing:
+          <<:
+        """
+        yaml_file = create_temp_yaml_file(tmp_path_factory, content)
+        assert False == get_yaml_data(yp, quiet_logger, yaml_file)
+        captured = capsys.readouterr()
+        assert -1 < captured.err.find("YAML construction error")
+
+    def test_get_yaml_data_syntax_error(
+        self, capsys, quiet_logger, tmp_path_factory, badsyntax_yaml_file
+    ):
+        yp = get_yaml_editor()
+        assert False == get_yaml_data(yp, quiet_logger, badsyntax_yaml_file)
+        captured = capsys.readouterr()
+        assert -1 < captured.err.find("YAML syntax error")
 
     def test_get_yaml_data_duplicatekey_error(
         self, capsys, quiet_logger, tmp_path_factory
@@ -89,7 +137,63 @@ class Test_func():
         captured = capsys.readouterr()
         assert -1 < captured.err.find("Duplicate YAML Anchor detected")
 
-    def test_get_yaml_data_construction_error(
+
+    ###
+    # get_yaml_multidoc_data
+    ###
+    def test_get_yaml_multidoc_data_keyboardinterrupt_error(
+        self, capsys, quiet_logger, tmp_path_factory,
+        force_ruamel_load_keyboardinterrupt
+    ):
+        yp = get_yaml_editor()
+        content = """---
+        no: ''
+        """
+        yaml_file = create_temp_yaml_file(tmp_path_factory, content)
+        docs_yielded = 0
+        for doc in get_yaml_multidoc_data(yp, quiet_logger, yaml_file):
+            docs_yielded += 1
+        assert docs_yielded == 0
+        captured = capsys.readouterr()
+        assert -1 < captured.err.find("keyboard interrupt")
+
+    def test_get_yaml_multidoc_data_filenotfound_error(
+        self, capsys, quiet_logger,
+        force_ruamel_load_keyboardinterrupt
+    ):
+        yp = get_yaml_editor()
+        docs_yielded = 0
+        for doc in get_yaml_multidoc_data(yp, quiet_logger, "no-such.file"):
+            docs_yielded += 1
+        assert docs_yielded == 0
+        captured = capsys.readouterr()
+        assert -1 < captured.err.find("File not found")
+
+    def test_get_yaml_multidoc_data_parser_error(
+        self, capsys, quiet_logger,
+        imparsible_yaml_file
+    ):
+        yp = get_yaml_editor()
+        docs_yielded = 0
+        for doc in get_yaml_multidoc_data(yp, quiet_logger, imparsible_yaml_file):
+            docs_yielded += 1
+        assert docs_yielded == 0
+        captured = capsys.readouterr()
+        assert -1 < captured.err.find("YAML parsing error")
+
+    def test_get_yaml_multidoc_data_composition_error(
+        self, capsys, quiet_logger,
+        badcmp_yaml_file
+    ):
+        yp = get_yaml_editor()
+        docs_yielded = 0
+        for doc in get_yaml_multidoc_data(yp, quiet_logger, badcmp_yaml_file):
+            docs_yielded += 1
+        assert docs_yielded == 0
+        captured = capsys.readouterr()
+        assert -1 < captured.err.find("YAML composition error")
+
+    def test_get_yaml_multidoc_data_construction_error(
         self, capsys, quiet_logger, tmp_path_factory
     ):
         yp = get_yaml_editor()
@@ -98,15 +202,70 @@ class Test_func():
           <<:
         """
         yaml_file = create_temp_yaml_file(tmp_path_factory, content)
-        assert False == get_yaml_data(yp, quiet_logger, yaml_file)
+        docs_yielded = 0
+        for doc in get_yaml_multidoc_data(yp, quiet_logger, yaml_file):
+            docs_yielded += 1
+        assert docs_yielded == 0
         captured = capsys.readouterr()
         assert -1 < captured.err.find("YAML construction error")
 
+    def test_get_yaml_multidoc_data_syntax_error(
+        self, capsys, quiet_logger, tmp_path_factory, badsyntax_yaml_file
+    ):
+        yp = get_yaml_editor()
+        docs_yielded = 0
+        for doc in get_yaml_multidoc_data(yp, quiet_logger, badsyntax_yaml_file):
+            docs_yielded += 1
+        assert docs_yielded == 0
+        captured = capsys.readouterr()
+        assert -1 < captured.err.find("YAML syntax error")
+
+    def test_get_yaml_multidoc_data_duplicatekey_error(
+        self, capsys, quiet_logger, tmp_path_factory
+    ):
+        yp = get_yaml_editor()
+        content = """---
+        key: value1
+        key: value2
+        """
+        yaml_file = create_temp_yaml_file(tmp_path_factory, content)
+        docs_yielded = 0
+        for doc in get_yaml_multidoc_data(yp, quiet_logger, yaml_file):
+            docs_yielded += 1
+        assert docs_yielded == 0
+        captured = capsys.readouterr()
+        assert -1 < captured.err.find("Duplicate Hash key detected")
+
+    def test_get_yaml_multidoc_data_duplicateanchor_error(
+        self, capsys, quiet_logger, tmp_path_factory
+    ):
+        yp = get_yaml_editor()
+        content = """---
+        aliases:
+          - &anchor value1
+          - &anchor value2
+        """
+        yaml_file = create_temp_yaml_file(tmp_path_factory, content)
+        docs_yielded = 0
+        for doc in get_yaml_multidoc_data(yp, quiet_logger, yaml_file):
+            docs_yielded += 1
+        assert docs_yielded == 0
+        captured = capsys.readouterr()
+        assert -1 < captured.err.find("Duplicate YAML Anchor detected")
+
+
+    ###
+    # append_list_element
+    ###
     def test_anchorless_list_element_error(self):
         with pytest.raises(ValueError) as ex:
             append_list_element({}, YAMLPath("foo"), "bar")
         assert -1 < str(ex.value).find("Impossible to add an Anchor")
 
+
+    ###
+    # wrap_type
+    ###
     @pytest.mark.parametrize("value,checktype", [
         ([], CommentedSeq),
         ({}, CommentedMap),
@@ -119,6 +278,10 @@ class Test_func():
     def test_wrap_type(self, value, checktype):
         assert isinstance(wrap_type(value), checktype)
 
+
+    ###
+    # clone_node
+    ###
     def test_clone_node(self):
         test_val = "test"
         assert test_val == clone_node(test_val)
@@ -126,6 +289,10 @@ class Test_func():
         anchor_val = PlainScalarString(test_val, anchor="anchor")
         assert anchor_val == clone_node(anchor_val)
 
+
+    ###
+    # make_new_node
+    ###
     @pytest.mark.parametrize("source,value,check,vformat", [
         ("", " ", " ", YAMLValueFormats.BARE),
         ("", '" "', '" "', YAMLValueFormats.DQUOTE),
@@ -151,10 +318,18 @@ class Test_func():
             value == make_new_node(source, value, vformat)
         assert -1 < str(ex.value).find(estr)
 
+
+    ###
+    # escape_path_section
+    ###
     def test_escape_path_section(self):
         from yamlpath.enums.pathseperators import PathSeperators
         assert r"a\\b\.c\(\)\[\]\^\$\%\ \'\"" == escape_path_section("a\\b.c()[]^$% '\"", PathSeperators.DOT)
 
+
+    ###
+    # create_searchterms_from_pathattributes
+    ###
     def test_create_searchterms_from_pathattributes(self):
         st = SearchTerms(False, PathSearchMethods.EQUALS, ".", "key")
         assert str(st) == str(create_searchterms_from_pathattributes(st))

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -45,7 +45,7 @@ class Test_func():
         force_ruamel_load_keyboardinterrupt
     ):
         yp = get_yaml_editor()
-        assert None == get_yaml_data(yp, quiet_logger, "no-such.file")
+        assert False == get_yaml_data(yp, quiet_logger, "no-such.file")
         captured = capsys.readouterr()
         assert -1 < captured.err.find("File not found")
 
@@ -58,7 +58,7 @@ class Test_func():
         no: ''
         """
         yaml_file = create_temp_yaml_file(tmp_path_factory, content)
-        assert None == get_yaml_data(yp, quiet_logger, yaml_file)
+        assert False == get_yaml_data(yp, quiet_logger, yaml_file)
         captured = capsys.readouterr()
         assert -1 < captured.err.find("keyboard interrupt")
 
@@ -71,7 +71,7 @@ class Test_func():
         key: value2
         """
         yaml_file = create_temp_yaml_file(tmp_path_factory, content)
-        assert None == get_yaml_data(yp, quiet_logger, yaml_file)
+        assert False == get_yaml_data(yp, quiet_logger, yaml_file)
         captured = capsys.readouterr()
         assert -1 < captured.err.find("Duplicate Hash key detected")
 
@@ -85,7 +85,7 @@ class Test_func():
           - &anchor value2
         """
         yaml_file = create_temp_yaml_file(tmp_path_factory, content)
-        assert None == get_yaml_data(yp, quiet_logger, yaml_file)
+        assert False == get_yaml_data(yp, quiet_logger, yaml_file)
         captured = capsys.readouterr()
         assert -1 < captured.err.find("Duplicate YAML Anchor detected")
 
@@ -98,7 +98,7 @@ class Test_func():
           <<:
         """
         yaml_file = create_temp_yaml_file(tmp_path_factory, content)
-        assert None == get_yaml_data(yp, quiet_logger, yaml_file)
+        assert False == get_yaml_data(yp, quiet_logger, yaml_file)
         captured = capsys.readouterr()
         assert -1 < captured.err.find("YAML construction error")
 

--- a/tests/test_merger_enums_outputdoctypes.py
+++ b/tests/test_merger_enums_outputdoctypes.py
@@ -1,0 +1,34 @@
+import pytest
+
+from yamlpath.merger.enums.outputdoctypes import (
+	OutputDocTypes)
+
+
+class Test_merger_enums_outputdoctypes():
+	"""Tests for the OutputDocTypes enumeration."""
+
+	def test_get_names(self):
+		assert OutputDocTypes.get_names() == [
+			"AUTO",
+			"JSON",
+			"YAML",
+		]
+
+	def test_get_choices(self):
+		assert OutputDocTypes.get_choices() == [
+			"auto",
+			"json",
+			"yaml",
+		]
+
+	@pytest.mark.parametrize("input,output", [
+		("AUTO", OutputDocTypes.AUTO),
+		("JSON", OutputDocTypes.JSON),
+		("YAML", OutputDocTypes.YAML),
+	])
+	def test_from_str(self, input, output):
+		assert output == OutputDocTypes.from_str(input)
+
+	def test_from_str_nameerror(self):
+		with pytest.raises(NameError):
+			OutputDocTypes.from_str("NO SUCH NAME")

--- a/tests/test_merger_mergerconfig.py
+++ b/tests/test_merger_mergerconfig.py
@@ -6,7 +6,8 @@ from yamlpath.merger.enums import (
     AnchorConflictResolutions,
     AoHMergeOpts,
     ArrayMergeOpts,
-    HashMergeOpts
+    HashMergeOpts,
+    OutputDocTypes
 )
 from yamlpath.wrappers import NodeCoords
 from yamlpath.merger import MergerConfig
@@ -30,6 +31,14 @@ class Test_merger_MergerConfig():
     def test_get_insertion_point_cli(self, quiet_logger):
         mc = MergerConfig(quiet_logger, SimpleNamespace(mergeat="la.tee.dah"))
         assert mc.get_insertion_point() == YAMLPath("/la/tee/dah")
+
+
+    ###
+    # get_document_format
+    ###
+    def test_get_document_format(self, quiet_logger):
+        mc = MergerConfig(quiet_logger, SimpleNamespace())
+        assert mc.get_document_format() == OutputDocTypes.AUTO
 
 
     ###

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -307,9 +307,7 @@ class Test_Processor():
         with pytest.raises(NotImplementedError):
             nodes = list(processor._get_nodes_by_search(
                 data,
-                SearchTerms(True, PathSearchMethods.DNF, ".", "top_scalar"),
-                None,
-                None
+                SearchTerms(True, PathSearchMethods.DNF, ".", "top_scalar")
             ))
 
     def test_adjoined_collectors_error(self, quiet_logger):

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -62,37 +62,66 @@ class Test_Processor():
         ("((&arrayOfHashes.step)[1])[0]", [2], True, None),
         ("does.not.previously.exist[7]", ["Huzzah!"], False, "Huzzah!"),
         ("/number_keys/1", ["one"], True, None),
+        ("**.[.^Hey]", ["Hey, Number Two!"], True, None),
+        ("/**/Hey*", ["Hey, Number Two!"], True, None),
+        ("lots_of_names.**.name", ["Name 1-1", "Name 2-1", "Name 3-1", "Name 4-1", "Name 4-2", "Name 4-3", "Name 4-4"], True, None),
     ])
     def test_get_nodes(self, quiet_logger, yamlpath, results, mustexist, default):
         yamldata = """---
-        aliases:
-          - &aliasAnchorOne Anchored Scalar Value
-          - &aliasAnchorTwo Hey, Number Two!
-        array_of_hashes: &arrayOfHashes
-          - step: 1
-            name: one
-          - step: 2
-            name: two
-        rollback_hashes:
-          on_condition:
-            failure:
-              - step: 3
-                name: three
-              - step: 4
-                name: four
-        disabled_steps:
-          - 2
-          - 3
-        squads:
-          alpha: 1.1
-          bravo: 2.2
-          charlie: 3.3
-          delta: 4.4
-        number_keys:
-          1: one
-          2: two
-          3: three
-        """
+aliases:
+  - &aliasAnchorOne Anchored Scalar Value
+  - &aliasAnchorTwo Hey, Number Two!
+array_of_hashes: &arrayOfHashes
+  - step: 1
+    name: one
+  - step: 2
+    name: two
+rollback_hashes:
+  on_condition:
+    failure:
+      - step: 3
+        name: three
+      - step: 4
+        name: four
+disabled_steps:
+  - 2
+  - 3
+squads:
+  alpha: 1.1
+  bravo: 2.2
+  charlie: 3.3
+  delta: 4.4
+number_keys:
+  1: one
+  2: two
+  3: three
+
+# For traversal tests:
+name: Name 0-0
+lots_of_names:
+  name: Name 1-1
+  tier1:
+    name: Name 2-1
+    tier2:
+      name: Name 3-1
+      list_of_named_objects:
+        - name: Name 4-1
+          tag: Tag 4-1
+          other: Other 4-1
+          dude: Dude 4-1
+        - tag: Tag 4-2
+          name: Name 4-2
+          dude: Dude 4-2
+          other: Other 4-2
+        - other: Other 4-3
+          dude: Dude 4-3
+          tag: Tag 4-3
+          name: Name 4-3
+        - dude: Dude 4-4
+          tag: Tag 4-4
+          name: Name 4-4
+          other: Other 4-4
+"""
         yaml = YAML()
         processor = Processor(quiet_logger, yaml.load(yamldata))
         matchidx = 0
@@ -601,3 +630,5 @@ class Test_Processor():
             assert unwrap_node_coords(node) == results[matchidx]
             matchidx += 1
         assert len(results) == matchidx
+
+    # TODO: test_collectors_expanded_via_star

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -28,6 +28,8 @@ class Test_Processor():
             matches += 1
         for node in processor._get_required_nodes(None, yamlpath):
             matches += 1
+        for node in processor._get_nodes_by_traversal(None, yamlpath, 0):
+            matches += 1
         assert matches == 0
 
     @pytest.mark.parametrize("yamlpath,results,mustexist,default", [
@@ -65,6 +67,7 @@ class Test_Processor():
         ("**.[.^Hey]", ["Hey, Number Two!"], True, None),
         ("/**/Hey*", ["Hey, Number Two!"], True, None),
         ("lots_of_names.**.name", ["Name 1-1", "Name 2-1", "Name 3-1", "Name 4-1", "Name 4-2", "Name 4-3", "Name 4-4"], True, None),
+        ("/array_of_hashes/**", [1, "one", 2, "two"], True, None),
     ])
     def test_get_nodes(self, quiet_logger, yamlpath, results, mustexist, default):
         yamldata = """---
@@ -155,6 +158,7 @@ lots_of_names:
         ("/floats/[.<4.F]", True),
         ("/floats/[.>=4.F]", True),
         ("/floats/[.<=4.F]", True),
+        ("abc.**", True),
     ])
     def test_get_impossible_nodes_error(self, quiet_logger, yamlpath, mustexist):
         yamldata = """---

--- a/tests/test_yamlpath.py
+++ b/tests/test_yamlpath.py
@@ -27,6 +27,16 @@ class Test_path_Path():
         ("abc[def$ghi]", PathSeperators.AUTO, "abc[def$ghi]"),
         ("/abc[def%1]", PathSeperators.AUTO, "/abc[def%1]"),
         ("abc[def%'ghi']", PathSeperators.AUTO, "abc[def%ghi]"),
+        ("abc*", PathSeperators.AUTO, "[.^abc]"),
+        ("*def", PathSeperators.AUTO, "[.$def]"),
+        ("a*f", PathSeperators.AUTO, "[.=~/^a.*f$/]"),
+        ("a*f*z", PathSeperators.AUTO, "[.=~/^a.*f.*z$/]"),
+        ("a*f*z*", PathSeperators.AUTO, "[.=~/^a.*f.*z.*$/]"),
+        ("*", PathSeperators.AUTO, "[.!=]"),
+        ("*.*", PathSeperators.AUTO, "[.!=][.!=]"),
+        ("**", PathSeperators.AUTO, "**"),
+        ("/**/def", PathSeperators.AUTO, "/**/def"),
+        ("abc.**.def", PathSeperators.AUTO, "abc.**.def"),
     ])
     def test_str(self, yamlpath, pathsep, output):
         # Test twice to include cache hits
@@ -171,3 +181,8 @@ class Test_path_Path():
         with pytest.raises(YAMLPathException) as ex:
             str(YAMLPath("abc.'def"))
         assert -1 < str(ex.value).find("contains at least one unmatched demarcation mark")
+
+    def test_parse_meaningless_traversal(self):
+        with pytest.raises(YAMLPathException) as ex:
+            str(YAMLPath("abc**"))
+        assert -1 < str(ex.value).find("The ** traversal operator has no meaning when combined with other characters")

--- a/yamlpath/commands/eyaml_rotate_keys.py
+++ b/yamlpath/commands/eyaml_rotate_keys.py
@@ -23,7 +23,7 @@ import yamlpath.patches
 from yamlpath.wrappers import ConsolePrinter
 
 # Implied Constants
-MY_VERSION = "1.0.3"
+MY_VERSION = "1.0.4"
 
 def processcli():
     """Process command-line arguments."""
@@ -126,7 +126,7 @@ def main():
 
         # Try to open the file
         yaml_data = get_yaml_data(yaml, log, yaml_file)
-        if yaml_data is None:
+        if not yaml_data and yaml_data is not None:
             # An error message has already been logged
             exit_state = 3
             continue

--- a/yamlpath/commands/yaml_get.py
+++ b/yamlpath/commands/yaml_get.py
@@ -24,7 +24,7 @@ from yamlpath.eyaml import EYAMLProcessor
 from yamlpath.wrappers import ConsolePrinter
 
 # Implied Constants
-MY_VERSION = "1.1.0"
+MY_VERSION = "1.2.0"
 
 def processcli():
     """Process command-line arguments."""

--- a/yamlpath/commands/yaml_get.py
+++ b/yamlpath/commands/yaml_get.py
@@ -151,7 +151,7 @@ def main():
     yaml_data = get_yaml_data(
         yaml, log,
         args.yaml_file if args.yaml_file else "-")
-    if yaml_data is None:
+    if not yaml_data and yaml_data is not None:
         # An error message has already been logged
         sys.exit(1)
 

--- a/yamlpath/commands/yaml_merge.py
+++ b/yamlpath/commands/yaml_merge.py
@@ -10,6 +10,7 @@ import sys
 import argparse
 from os import access, R_OK
 from os.path import isfile, exists
+from typing import Any
 
 from yamlpath.merger.enums import (
     AnchorConflictResolutions,
@@ -193,7 +194,7 @@ def validateargs(args, log):
 
 def main():
     """Main code."""
-    def process_rhs(rhs_file: str):
+    def process_rhs(rhs_yaml: Any, rhs_file: str):
         # Except for - (STDIN), each YAML_FILE must actually be a file; because
         # merge data is expected, this is a fatal failure.
         if rhs_file != "-" and not isfile(rhs_file):
@@ -252,7 +253,7 @@ def main():
     exit_state = 0
     rhs_yaml = get_yaml_editor()
     for rhs_file in fileiterator:
-        proc_state = process_rhs(rhs_file)
+        proc_state = process_rhs(rhs_yaml, rhs_file)
 
         if rhs_file.strip() == '-':
             consumed_stdin = True
@@ -263,10 +264,11 @@ def main():
 
     # Check for a waiting STDIN document
     if not consumed_stdin and not args.nostdin and not sys.stdin.isatty():
-        exit_state = process_rhs('-')
+        exit_state = process_rhs(rhs_yaml, '-')
 
     # Output the final document
     if exit_state == 0:
+        merger.configure_writer_for_dump(prime_yaml)
         if args.output:
             with open(args.output, 'w') as yaml_dump:
                 prime_yaml.dump(merger.data, yaml_dump)

--- a/yamlpath/commands/yaml_merge.py
+++ b/yamlpath/commands/yaml_merge.py
@@ -206,14 +206,6 @@ def merge_multidoc(yaml_file, yaml_editor, log, merger):
     """Merge all documents within a multi-document source."""
     exit_state = 1
     for yaml_data in get_yaml_multidoc_data(yaml_editor, log, yaml_file):
-        log.debug(
-            "merge_multidoc:  Got data of type {}:".format(type(yaml_data)))
-        log.debug(yaml_data)
-        if not yaml_data and yaml_data is not None:
-            # An error has already been logged
-            exit_state = 1
-            break
-
         try:
             merger.merge_with(yaml_data)
         except MergeException as mex:

--- a/yamlpath/commands/yaml_merge.py
+++ b/yamlpath/commands/yaml_merge.py
@@ -163,7 +163,6 @@ def validateargs(args, log):
     input_file_count = len(args.rhs_files)
     if (input_file_count == 0 and (
             sys.stdin.isatty()
-            or args.rhs_files[0].strip() == '-'
             or args.nostdin)
     ):
         has_errors = True
@@ -255,7 +254,7 @@ def main():
         explode_aliases=document_is_json,
         preserve_quotes=document_is_yaml
     )
-    prime_file = next(fileiterator)
+    prime_file = next(fileiterator, '-')
     consumed_stdin = prime_file.strip() == '-'
     got_prime_data = False
     merger = Merger(log, None, MergerConfig(log, args))

--- a/yamlpath/commands/yaml_merge.py
+++ b/yamlpath/commands/yaml_merge.py
@@ -149,7 +149,7 @@ def processcli():
             "-o|--output is not set)"))
 
     parser.add_argument(
-        "rhs_files", metavar="YAML_FILE", nargs="+",
+        "rhs_files", metavar="YAML_FILE", nargs="*",
         help=(
             "one or more YAML files to merge, order-significant;\n"
             "use - to read from STDIN"))
@@ -159,18 +159,16 @@ def validateargs(args, log):
     """Validate command-line arguments."""
     has_errors = False
 
-    # There must be at least two input files
+    # There must be at least one input file or stream
     input_file_count = len(args.rhs_files)
-    if (input_file_count == 0
-        or input_file_count == 1 and (
+    if (input_file_count == 0 and (
             sys.stdin.isatty()
             or args.rhs_files[0].strip() == '-'
             or args.nostdin)
     ):
         has_errors = True
         log.error(
-            "There must be at least two YAML_FILEs and only one may be the -"
-            " pseudo-file, explicit or implied.")
+            "There must be at least one YAML_FILE.")
 
     # There can be only one -
     pseudofile_count = 0
@@ -245,6 +243,7 @@ def main():
     # Is the output JSON?
     document_format = OutputDocTypes.from_str(args.document_format)
     output_file = args.output
+    output_is_json = False
     if output_file:
         output_is_json = Path(output_file).suffix.lower() == ".json"
     document_is_json = document_format is OutputDocTypes.JSON or output_is_json

--- a/yamlpath/commands/yaml_merge.py
+++ b/yamlpath/commands/yaml_merge.py
@@ -25,7 +25,7 @@ from yamlpath.exceptions import YAMLPathException
 from yamlpath.wrappers import ConsolePrinter
 
 # Implied Constants
-MY_VERSION = "0.0.4"
+MY_VERSION = "0.1.0"
 
 def processcli():
     """Process command-line arguments."""
@@ -53,7 +53,7 @@ def processcli():
             pseudo-file.  When only one YAML_FILE is provided, it cannot be the
             - pseudo-file and in this special-case - will be inferred as the
             second YAML_FILE as long as you are running this program without a
-            TTY.
+            TTY (unless you set --nostdin|-S).
             For more information about YAML Paths, please visit
             https://github.com/wwkimball/yamlpath."""
     )
@@ -115,6 +115,12 @@ def processcli():
             "Write the merged result to the indicated file (or\n"
             "STDOUT when unset)"))
 
+    parser.add_argument(
+        "-S", "--nostdin", action="store_true",
+        help=(
+            "Do not implicitly read from STDIN, even when there are\n"
+            "no - pseudo-files in YAML_FILEs with a non-TTY session"))
+
     noise_group = parser.add_mutually_exclusive_group()
     noise_group.add_argument(
         "-d", "--debug", action="store_true",
@@ -142,8 +148,10 @@ def validateargs(args, log):
     # There must be at least two input files
     input_file_count = len(args.rhs_files)
     if (input_file_count == 0
-        or input_file_count == 1 and sys.stdin.isatty()
-        or input_file_count == 1 and args.rhs_files[0].strip() == '-'
+        or input_file_count == 1 and (
+            sys.stdin.isatty()
+            or args.rhs_files[0].strip() == '-'
+            or args.nostdin)
     ):
         has_errors = True
         log.error(
@@ -151,11 +159,11 @@ def validateargs(args, log):
             " pseudo-file, explicit or implied.")
 
     # There can be only one -
-    found_dashes = 0
+    pseudofile_count = 0
     for infile in args.rhs_files:
         if infile.strip() == '-':
-            found_dashes += 1
-    if found_dashes > 1:
+            pseudofile_count += 1
+    if pseudofile_count > 1:
         has_errors = True
         log.error("Only one YAML_FILE may be the - pseudo-file.")
 
@@ -185,6 +193,35 @@ def validateargs(args, log):
 
 def main():
     """Main code."""
+    def process_rhs(rhs_file: str):
+        # Except for - (STDIN), each YAML_FILE must actually be a file; because
+        # merge data is expected, this is a fatal failure.
+        if rhs_file != "-" and not isfile(rhs_file):
+            log.error("Not a file:  {}".format(rhs_file))
+            return 2
+
+        log.info("Processing {}..."
+                 .format("STDIN" if rhs_file == "-" else rhs_file))
+
+        # Try to open the file; failures are fatal
+        rhs_data = get_yaml_data(rhs_yaml, log, rhs_file)
+        if rhs_data is None:
+            # An error message has already been logged
+            return 3
+
+        # Merge the new RHS into the prime LHS
+        exit_state = 0
+        try:
+            merger.merge_with(rhs_data)
+        except MergeException as mex:
+            log.error(mex)
+            exit_state = 4
+        except YAMLPathException as yex:
+            log.error(yex)
+            exit_state = 5
+
+        return exit_state
+
     args = processcli()
     log = ConsolePrinter(args)
     validateargs(args, log)
@@ -193,6 +230,7 @@ def main():
     fileiterator = iter(args.rhs_files)
     prime_yaml = get_yaml_editor()
     prime_file = next(fileiterator)
+    consumed_stdin = prime_file.strip() == '-'
     prime_data = get_yaml_data(prime_yaml, log, prime_file)
     if prime_data is None:
         # An error message has already been logged
@@ -214,32 +252,18 @@ def main():
     exit_state = 0
     rhs_yaml = get_yaml_editor()
     for rhs_file in fileiterator:
-        # Except for - (STDIN), each YAML_FILE must actually be a file; because
-        # merge data is expected, this is a fatal failure.
-        if rhs_file != "-" and not isfile(rhs_file):
-            log.error("Not a file:  {}".format(rhs_file))
-            exit_state = 2
+        proc_state = process_rhs(rhs_file)
+
+        if rhs_file.strip() == '-':
+            consumed_stdin = True
+
+        if proc_state != 0:
+            exit_state = proc_state
             break
 
-        log.info("Processing {}..."
-                 .format("STDIN" if rhs_file == "-" else rhs_file))
-
-        # Try to open the file; failures are fatal
-        rhs_data = get_yaml_data(rhs_yaml, log, rhs_file)
-        if rhs_data is None:
-            # An error message has already been logged
-            exit_state = 3
-            break
-
-        # Merge the new RHS into the prime LHS
-        try:
-            merger.merge_with(rhs_data)
-        except MergeException as mex:
-            log.error(mex)
-            exit_state = 4
-        except YAMLPathException as yex:
-            log.error(yex)
-            exit_state = 5
+    # Check for a waiting STDIN document
+    if not consumed_stdin and not args.nostdin and not sys.stdin.isatty():
+        exit_state = process_rhs('-')
 
     # Output the final document
     if exit_state == 0:

--- a/yamlpath/commands/yaml_paths.py
+++ b/yamlpath/commands/yaml_paths.py
@@ -37,7 +37,7 @@ from yamlpath.wrappers import ConsolePrinter
 from yamlpath.eyaml import EYAMLProcessor
 
 # Implied Constants
-MY_VERSION = "0.2.0"
+MY_VERSION = "0.2.1"
 
 def processcli():
     """Process command-line arguments."""
@@ -723,7 +723,7 @@ def main():
     for yaml_file in args.yaml_files:
         # Try to open the file
         yaml_data = get_yaml_data(yaml, log, yaml_file)
-        if yaml_data is None:
+        if not yaml_data and yaml_data is not None:
             # An error message has already been logged
             exit_state = 3
             continue

--- a/yamlpath/commands/yaml_set.py
+++ b/yamlpath/commands/yaml_set.py
@@ -18,7 +18,12 @@ from os import remove, access, R_OK
 from os.path import isfile, exists
 from shutil import copy2, copyfileobj
 
-from yamlpath.func import clone_node, get_yaml_data, get_yaml_editor
+from yamlpath.func import (
+    clone_node,
+    build_next_node,
+    get_yaml_data,
+    get_yaml_editor
+)
 from yamlpath import YAMLPath
 from yamlpath.exceptions import YAMLPathException
 from yamlpath.enums import YAMLValueFormats, PathSeperators
@@ -206,6 +211,8 @@ def main():
     # Attempt to open the YAML file; check for parsing errors
     yaml_data = get_yaml_data(yaml, log, args.yaml_file)
     if yaml_data is None:
+        yaml_data = build_next_node(change_path, 0, new_value)
+    elif not yaml_data:
         # An error message has already been logged
         sys.exit(1)
 

--- a/yamlpath/commands/yaml_set.py
+++ b/yamlpath/commands/yaml_set.py
@@ -212,7 +212,7 @@ def main():
     yaml_data = get_yaml_data(yaml, log, args.yaml_file)
     if yaml_data is None:
         yaml_data = build_next_node(change_path, 0, new_value)
-    elif not yaml_data:
+    elif not yaml_data and isinstance(yaml_data, bool):
         # An error message has already been logged
         sys.exit(1)
 

--- a/yamlpath/commands/yaml_set.py
+++ b/yamlpath/commands/yaml_set.py
@@ -31,7 +31,7 @@ import yamlpath.patches
 from yamlpath.wrappers import ConsolePrinter
 
 # Implied Constants
-MY_VERSION = "1.0.8"
+MY_VERSION = "1.1.0"
 
 def processcli():
     """Process command-line arguments."""

--- a/yamlpath/enums/pathsegmenttypes.py
+++ b/yamlpath/enums/pathsegmenttypes.py
@@ -28,6 +28,11 @@ class PathSegmentTypes(Enum):
 
     `SEARCH`
         A search operation for which results are returned as they are matched.
+
+    `TRAVERSE`
+        Traverses the document tree deeply.  If there is a next segment, it
+        must match or no data is matched.  When there is no next segment, every
+        leaf node matches.
     """
 
     ANCHOR = auto()
@@ -35,3 +40,4 @@ class PathSegmentTypes(Enum):
     INDEX = auto()
     KEY = auto()
     SEARCH = auto()
+    TRAVERSE = auto()

--- a/yamlpath/func.py
+++ b/yamlpath/func.py
@@ -110,8 +110,6 @@ def get_yaml_data(parser: Any, logger: ConsolePrinter, source: str) -> Any:
                      .format(str(ex.problem_mark).lstrip(), ex.problem))
         yaml_data = None
     except ComposerError as ex:
-        # TODO:  ERROR:  YAML composition error in "combo.json", line 12, column 1:  but found another document
-        # TODO:  ERROR:  YAML composition error in "combo.yaml", line 16, column 1:  but found another document
         logger.error("YAML composition error {}:  {}"
                      .format(str(ex.problem_mark).lstrip(), ex.problem))
         yaml_data = None

--- a/yamlpath/func.py
+++ b/yamlpath/func.py
@@ -39,23 +39,42 @@ from yamlpath.types import PathAttributes
 from yamlpath.path import SearchTerms
 from yamlpath import YAMLPath
 
-def get_yaml_editor() -> Any:
+def get_yaml_editor(**kwargs: Any) -> Any:
     """
     Build and return a generic YAML editor based on ruamel.yaml.
 
     Parameters:  N/A
 
+    Keyword Arguments:
+    * explicit_start (bool) True = ensure the YAML Start-of-Document marker
+      (---<EOL>) is written in the output; False = remove it; default=True
+    * explode_aliases (bool) True = convert all aliases (*name) and YAML merge
+      operators (<<: *name) to their referenced content, removing the aliases
+      and merge operators; False = maintain the references; default=False
+    * preserve_quotes (bool) True = retain any and all quoting of keys and
+      values including whatever demarcation symbol was used (" versus ');
+      False = only quote values when necessary, removing unnecessary
+      demarcation; default=True
+
     Returns (Any) The ready-for-use YAML editor.
 
     Raises:  N/A
     """
+    explicit_start = kwargs.pop("explicit_start", True)
+    explode_aliases = kwargs.pop("explode_aliases", False)
+    preserve_quotes = kwargs.pop("preserve_quotes", True)
+
     # The ruamel.yaml class appears to be missing some typing data, so these
     # valid assignments cannot be type-checked.
     yaml = YAML()
     yaml.indent(mapping=2, sequence=4, offset=2)
-    yaml.explicit_start = True      # type: ignore
-    yaml.preserve_quotes = True     # type: ignore
-    yaml.width = maxsize            # type: ignore
+    yaml.explicit_start = explicit_start       # type: ignore
+    yaml.preserve_quotes = preserve_quotes     # type: ignore
+    yaml.width = maxsize                       # type: ignore
+
+    if explode_aliases:
+        yaml.default_flow_style = False
+
     return yaml
 
 # pylint: disable=locally-disabled,too-many-branches,too-many-statements

--- a/yamlpath/func.py
+++ b/yamlpath/func.py
@@ -101,26 +101,26 @@ def get_yaml_data(parser: Any, logger: ConsolePrinter, source: str) -> Any:
                     yaml_data = parser.load(fhnd)
     except KeyboardInterrupt:
         logger.error("Aborting data load due to keyboard interrupt!")
-        yaml_data = None
+        yaml_data = False
     except FileNotFoundError:
         logger.error("File not found:  {}".format(source))
-        yaml_data = None
+        yaml_data = False
     except ParserError as ex:
         logger.error("YAML parsing error {}:  {}"
                      .format(str(ex.problem_mark).lstrip(), ex.problem))
-        yaml_data = None
+        yaml_data = False
     except ComposerError as ex:
         logger.error("YAML composition error {}:  {}"
                      .format(str(ex.problem_mark).lstrip(), ex.problem))
-        yaml_data = None
+        yaml_data = False
     except ConstructorError as ex:
         logger.error("YAML construction error {}:  {}"
                      .format(str(ex.problem_mark).lstrip(), ex.problem))
-        yaml_data = None
+        yaml_data = False
     except ScannerError as ex:
         logger.error("YAML syntax error {}:  {}"
                      .format(str(ex.problem_mark).lstrip(), ex.problem))
-        yaml_data = None
+        yaml_data = False
     except DuplicateKeyError as dke:
         omits = [
             "while constructing", "To suppress this", "readthedocs",
@@ -141,14 +141,14 @@ def get_yaml_data(parser: Any, logger: ConsolePrinter, source: str) -> Any:
                 newmsg += "\n   " + line
         logger.error("Duplicate Hash key detected:  {}"
                      .format(newmsg))
-        yaml_data = None
+        yaml_data = False
     except ReusedAnchorWarning as raw:
         logger.error("Duplicate YAML Anchor detected:  {}"
                      .format(
                          str(raw)
                          .replace("occurrence   ", "occurrence ")
                          .replace("\n", "\n   ")))
-        yaml_data = None
+        yaml_data = False
 
     return yaml_data
 

--- a/yamlpath/func.py
+++ b/yamlpath/func.py
@@ -8,7 +8,7 @@ import ast
 import re
 from sys import maxsize, stdin
 from distutils.util import strtobool
-from typing import Any, List, Optional
+from typing import Any, Generator, List, Optional
 
 from ruamel.yaml import YAML
 from ruamel.yaml.parser import ParserError
@@ -134,6 +134,86 @@ def get_yaml_data(parser: Any, logger: ConsolePrinter, source: str) -> Any:
         yaml_data = None
 
     return yaml_data
+
+# pylint: disable=locally-disabled,too-many-branches,too-many-statements,too-many-locals
+def get_yaml_multidoc_data(
+    parser: Any, logger: ConsolePrinter, source: str
+) -> Generator[Any, None, None]:
+    """
+    Parse YAML/Compatible multi-docs and yield the ruamel.yaml object results.
+
+    All known issues are caught and distinctively logged.  Nothing is generated
+    when there is an error.
+
+    Parameters:
+    1. parser (ruamel.yaml.YAML) The YAML data parser
+    2. logger (ConsolePrinter) The logging facility
+    3. source (str) The source file to load; can be - for reading from STDIN
+    """
+    # This code traps errors and warnings from ruamel.yaml, substituting
+    # lengthy stack-dumps with specific, meaningful feedback.  Further, some
+    # warnings are treated as errors by ruamel.yaml, so these are also
+    # coallesced into cleaner feedback.
+    try:
+        with warnings.catch_warnings():
+            warnings.filterwarnings("error")
+            if source == "-":
+                for document in parser.load_all(stdin.read()):
+                    logger.debug(
+                        "get_yaml_multidoc_data: Yielding document from {}:"
+                        .format(source))
+                    logger.debug(document)
+                    yield document
+            else:
+                with open(source, 'r') as fhnd:
+                    for document in parser.load_all(fhnd):
+                        logger.debug(
+                            "get_yaml_multidoc_data: Yielding document from"
+                            " {}:".format(source))
+                        logger.debug(document)
+                        yield document
+    except KeyboardInterrupt:
+        logger.error("Aborting data load due to keyboard interrupt!")
+    except FileNotFoundError:
+        logger.error("File not found:  {}".format(source))
+    except ParserError as ex:
+        logger.error("YAML parsing error {}:  {}"
+                     .format(str(ex.problem_mark).lstrip(), ex.problem))
+    except ComposerError as ex:
+        logger.error("YAML composition error {}:  {}"
+                    .format(str(ex.problem_mark).lstrip(), ex.problem))
+    except ConstructorError as ex:
+        logger.error("YAML construction error {}:  {}"
+                     .format(str(ex.problem_mark).lstrip(), ex.problem))
+    except ScannerError as ex:
+        logger.error("YAML syntax error {}:  {}"
+                     .format(str(ex.problem_mark).lstrip(), ex.problem))
+    except DuplicateKeyError as dke:
+        omits = [
+            "while constructing", "To suppress this", "readthedocs",
+            "future releases", "the new API",
+        ]
+        message = str(dke).split("\n")
+        newmsg = ""
+        for line in message:
+            line = line.strip()
+            if not line:
+                continue
+            write_line = True
+            for omit in omits:
+                if omit in line:
+                    write_line = False
+                    break
+            if write_line:
+                newmsg += "\n   " + line
+        logger.error("Duplicate Hash key detected:  {}"
+                     .format(newmsg))
+    except ReusedAnchorWarning as raw:
+        logger.error("Duplicate YAML Anchor detected:  {}"
+                     .format(
+                         str(raw)
+                         .replace("occurrence   ", "occurrence ")
+                         .replace("\n", "\n   ")))
 
 def build_next_node(yaml_path: YAMLPath, depth: int,
                     value: Any = None) -> Any:

--- a/yamlpath/func.py
+++ b/yamlpath/func.py
@@ -686,31 +686,3 @@ def unwrap_node_coords(data: Any) -> Any:
         return stripped_nodes
 
     return data
-
-def quote_every_string(data: Any) -> Any:
-    """Recursively quote every String in a DOM (presumably for JSON)."""
-    if isinstance(data, dict):
-        # Quote every unquoted string key
-        for key_idx, key_name in [
-            (idx, key)
-            for idx, key in enumerate(data.keys())
-            if isinstance(key, str)
-                and not isinstance(key, (DoubleQuotedScalarString,
-                                         SingleQuotedScalarString))
-        ]:
-            data.insert(
-                key_idx, DoubleQuotedScalarString(key_name),
-                data.pop(key_name))
-
-        # Quote every unquoted string value
-        for key, val in data.items():
-            data[key] = quote_every_string(val)
-    elif isinstance(data, list):
-        for idx, ele in enumerate(data):
-            data[idx] = quote_every_string(ele)
-    elif (isinstance(data, str)
-          and not isinstance(data, (DoubleQuotedScalarString,
-                                    SingleQuotedScalarString))
-    ):
-        return DoubleQuotedScalarString(data)
-    return data

--- a/yamlpath/func.py
+++ b/yamlpath/func.py
@@ -58,28 +58,58 @@ def get_yaml_editor() -> Any:
     yaml.width = maxsize            # type: ignore
     return yaml
 
-# pylint: disable=locally-disabled,too-many-branches,too-many-statements
-def get_yaml_data(parser: Any, logger: ConsolePrinter, source: str) -> Any:
+# pylint: disable=locally-disabled,too-many-branches,too-many-statements,too-many-locals
+def get_yaml_data(
+    parser: Any, logger: ConsolePrinter, source: str, **kwargs: Any
+) -> Any:
     """
     Parse YAML/Compatible data and return the ruamel.yaml object result.
 
     All known issues are caught and distinctively logged.  Returns None when
     the data could not be loaded.
+
+    Parameters:
+    1. parser (ruamel.yaml.YAML) The YAML data parser
+    2. logger (ConsolePrinter) The logging facility
+    3. source (str) The source file to load; can be - for reading from STDIN
+
+    Keyword Arguments:
+    * allow_multidoc (bool) True = permit automatic multi-document (multiple
+      YAML/JSON/Compatible documents within a single file) loading; False = do
+      not allow automatic switching from a single- to a multi-document load;
+      default=False
+    * load_multidoc (bool) True = perform a multi-document load; False = load
+      only a single-document file; default=False
     """
     yaml_data = None
+    allow_multidoc = kwargs.pop("allow_multidoc", False)
+    load_multidoc = kwargs.pop("load_multidoc", False)
+
+    logger.debug(
+        "get_yaml_data:  Running with allow_multidoc={}, load_multidoc={}"
+        " against source {}.".format(allow_multidoc, load_multidoc, source))
 
     # This code traps errors and warnings from ruamel.yaml, substituting
     # lengthy stack-dumps with specific, meaningful feedback.  Further, some
     # warnings are treated as errors by ruamel.yaml, so these are also
     # coallesced into cleaner feedback.
+    load_method = parser.load_all if load_multidoc else parser.load
     try:
         with warnings.catch_warnings():
             warnings.filterwarnings("error")
             if source == "-":
-                yaml_data = parser.load(stdin.read())
+                yaml_data = load_method(stdin.read())
             else:
                 with open(source, 'r') as fhnd:
-                    yaml_data = parser.load(fhnd)
+                    if load_multidoc:
+                        for document in load_method(fhnd):
+                            logger.debug(
+                                "get_yaml_data: Yielding document from {}:"
+                                .format(source))
+                            logger.debug(document)
+                            yield document
+                        return
+                    yaml_data = load_method(fhnd)
     except KeyboardInterrupt:
         logger.error("Aborting data load due to keyboard interrupt!")
         yaml_data = None
@@ -91,10 +121,22 @@ def get_yaml_data(parser: Any, logger: ConsolePrinter, source: str) -> Any:
                      .format(str(ex.problem_mark).lstrip(), ex.problem))
         yaml_data = None
     except ComposerError as ex:
-        # TODO:  ERROR:  YAML composition error in "combo.json", line 12, column 1:  but found another document
-        # TODO:  ERROR:  YAML composition error in "combo.yaml", line 16, column 1:  but found another document
+        if (allow_multidoc
+            and not load_multidoc
+            and "found another document" in ex.problem
+        ):
+            for document in get_yaml_data(
+                parser, logger, source, load_multidoc=True
+            ):
+                logger.debug(
+                    "get_yaml_data: Subyielding document from {}:"
+                    .format(source))
+                logger.debug(document)
+                yield document
+            return
+
         logger.error("YAML composition error {}:  {}"
-                     .format(str(ex.problem_mark).lstrip(), ex.problem))
+                    .format(str(ex.problem_mark).lstrip(), ex.problem))
         yaml_data = None
     except ConstructorError as ex:
         logger.error("YAML construction error {}:  {}"
@@ -133,6 +175,8 @@ def get_yaml_data(parser: Any, logger: ConsolePrinter, source: str) -> Any:
                          .replace("\n", "\n   ")))
         yaml_data = None
 
+    logger.debug("get_yaml_data: Returning document from {}:".format(source))
+    logger.debug(yaml_data)
     return yaml_data
 
 def build_next_node(yaml_path: YAMLPath, depth: int,

--- a/yamlpath/merger/enums/__init__.py
+++ b/yamlpath/merger/enums/__init__.py
@@ -3,3 +3,4 @@ from .anchorconflictresolutions import AnchorConflictResolutions
 from .aohmergeopts import AoHMergeOpts
 from .arraymergeopts import ArrayMergeOpts
 from .hashmergeopts import HashMergeOpts
+from .outputdoctypes import OutputDocTypes

--- a/yamlpath/merger/enums/outputdoctypes.py
+++ b/yamlpath/merger/enums/outputdoctypes.py
@@ -16,16 +16,16 @@ class OutputDocTypes(Enum):
     `AUTO`
         The output type is inferred from the first source document.
 
-    `YAML`
-        Force output to be YAML.
-
     `JSON`
         Force output to be JSON.
+
+    `YAML`
+        Force output to be YAML.
     """
 
     AUTO = auto()
-    YAML = auto()
     JSON = auto()
+    YAML = auto()
 
     @staticmethod
     def get_names() -> List[str]:

--- a/yamlpath/merger/enums/outputdoctypes.py
+++ b/yamlpath/merger/enums/outputdoctypes.py
@@ -1,0 +1,80 @@
+"""
+Implements the OutputDocTypes enumeration.
+
+Copyright 2020 William W. Kimball, Jr. MBA MSIS
+"""
+from enum import Enum, auto
+from typing import List
+
+
+class OutputDocTypes(Enum):
+    """
+    Supported Output Document Types.
+
+    Options include:
+
+    `AUTO`
+        The output type is inferred from the first source document.
+
+    `YAML`
+        Force output to be YAML.
+
+    `JSON`
+        Force output to be JSON.
+    """
+
+    AUTO = auto()
+    YAML = auto()
+    JSON = auto()
+
+    @staticmethod
+    def get_names() -> List[str]:
+        """
+        Get all upper-cased entry names for this enumeration.
+
+        Parameters:  N/A
+
+        Returns:  (List[str]) Upper-case names from this enumeration
+
+        Raises:  N/A
+        """
+        return [entry.name.upper() for entry in OutputDocTypes]
+
+    @staticmethod
+    def get_choices() -> List[str]:
+        """
+        Get all entry names with symbolic representations for this enumeration.
+
+        All returned entries are lower-cased.
+
+        Parameters:  N/A
+
+        Returns:  (List[str]) Lower-case names and symbols from this
+            enumeration
+
+        Raises:  N/A
+        """
+        names = [l.lower() for l in OutputDocTypes.get_names()]
+        choices = list(set(names))
+        choices.sort()
+        return choices
+
+    @staticmethod
+    def from_str(name: str) -> "OutputDocTypes":
+        """
+        Convert a string value to a value of this enumeration, if valid.
+
+        Parameters:
+            1. name (str) The name to convert
+
+        Returns:  (OutputDocTypes) the converted enumeration value
+
+        Raises:
+            - `NameError` when name doesn't match any enumeration values
+        """
+        check: str = str(name).upper()
+        if check in OutputDocTypes.get_names():
+            return OutputDocTypes[check]
+        raise NameError(
+            "OutputDocTypes has no such item:  {}"
+            .format(name))

--- a/yamlpath/merger/merger.py
+++ b/yamlpath/merger/merger.py
@@ -172,9 +172,7 @@ class Merger:
                 .format(ele, type(ele), path_next))
 
             if append_all or (ele not in lhs):
-                append_list_element(
-                    lhs, ele,
-                    ele.anchor.value if hasattr(ele, "anchor") else None)
+                lhs.append(ele)
         return lhs
 
     # pylint: disable=locally-disabled,too-many-branches
@@ -413,6 +411,9 @@ class Merger:
         insert_at = self.config.get_insertion_point()
         if self.data is None:
             self.data = build_next_node(insert_at, 0, rhs)
+            if isinstance(rhs, (dict, list)):
+                # Only Scalar values need further processing
+                return
 
         # Remove all comments (no sensible way to merge them)
         Merger.delete_all_comments(rhs)

--- a/yamlpath/merger/merger.py
+++ b/yamlpath/merger/merger.py
@@ -504,11 +504,9 @@ class Merger:
         doc_format = self.config.get_document_format()
         if doc_format is OutputDocTypes.AUTO:
             # Check whether the document root is in flow or block format.
-            is_flow = False
+            is_flow = True
             if hasattr(self.data, "fa"):
                 is_flow = self.data.fa.flow_style()
-            else:
-                is_flow = True
         else:
             is_flow = doc_format is OutputDocTypes.JSON
 

--- a/yamlpath/merger/mergerconfig.py
+++ b/yamlpath/merger/mergerconfig.py
@@ -12,7 +12,8 @@ from yamlpath.merger.enums import (
     AnchorConflictResolutions,
     AoHMergeOpts,
     ArrayMergeOpts,
-    HashMergeOpts
+    HashMergeOpts,
+    OutputDocTypes,
 )
 from yamlpath import Processor, YAMLPath
 from yamlpath.wrappers import ConsolePrinter, NodeCoords
@@ -181,6 +182,12 @@ class MergerConfig:
         if hasattr(self.args, "mergeat"):
             return YAMLPath(self.args.mergeat)
         return YAMLPath("/")
+
+    def get_document_format(self) -> OutputDocTypes:
+        """Get the user-desired output format."""
+        if hasattr(self.args, "document_format"):
+            return OutputDocTypes.from_str(self.args.document_format)
+        return OutputDocTypes.AUTO
 
     def _prepare_user_rules(
         self, proc: Processor, merge_path: YAMLPath, section: str,

--- a/yamlpath/processor.py
+++ b/yamlpath/processor.py
@@ -1050,8 +1050,8 @@ class Processor:
         def recurse(data, parent, parentref, reference_node, replacement_node):
             if isinstance(data, dict):
                 for i, k in [
-                        (idx, key) for idx, key in
-                        enumerate(data.keys()) if key is reference_node
+                        (idx, key) for idx, key in enumerate(data.keys())
+                        if key is reference_node
                 ]:
                     data.insert(i, replacement_node, data.pop(k))
                 for k, val in data.items():

--- a/yamlpath/processor.py
+++ b/yamlpath/processor.py
@@ -1054,7 +1054,7 @@ class Processor:
                         enumerate(data.keys()) if key is reference_node
                 ]:
                     data.insert(i, replacement_node, data.pop(k))
-                for k, val in data.non_merged_items():
+                for k, val in data.items():
                     if val is reference_node:
                         if (hasattr(val, "anchor") or
                                 (data is parent and k == parentref)):

--- a/yamlpath/processor.py
+++ b/yamlpath/processor.py
@@ -331,8 +331,8 @@ class Processor:
                 and isinstance(stripped_attrs, CollectorTerms)
         ):
             node_coords = self._get_nodes_by_collector(
-                data, yaml_path, segment_index, stripped_attrs,
-                parent, parentref)
+                data, yaml_path, segment_index,
+                yaml_path.unescaped[segment_index][1], parent, parentref)
         elif segment_type == PathSegmentTypes.TRAVERSE:
             node_coords = self._get_nodes_by_traversal(
                 data, yaml_path, segment_index, parent=parent,
@@ -596,6 +596,9 @@ class Processor:
             return
 
         node_coords = []    # A list of NodeCoords
+        self.logger.debug(
+            "Processor::_get_nodes_by_collector:  Getting required nodes"
+            " matching search expression:  {}".format(terms.expression))
         for node_coord in self._get_required_nodes(
                 data, YAMLPath(terms.expression), 0, parent, parentref):
             node_coords.append(node_coord)

--- a/yamlpath/processor.py
+++ b/yamlpath/processor.py
@@ -179,115 +179,6 @@ class Processor:
                     node_coord.parent, node_coord.parentref, value,
                     value_format)
 
-    # pylint: disable=locally-disabled,too-many-branches
-    def _get_nodes_by_traversal(self, data: Any, yaml_path: YAMLPath,
-                                segment_index: int, **kwargs: Any
-                                ) -> Generator[Any, None, None]:
-        """
-        Deeply traverse the document tree, returning all or filtered nodes.
-
-        Parameters:
-        1. data (ruamel.yaml data) The parsed YAML data to process
-        2. yaml_path (yamlpath.Path) The YAML Path being processed
-        3. segment_index (int) Segment index of the YAML Path to process
-
-        Keyword Parameters:
-        * parent (ruamel.yaml node) The parent node from which this query
-          originates
-        * parentref (Any) The Index or Key of data within parent
-
-        Returns:  (Generator[Any, None, None]) Each node coordinate as they are
-        matched.
-        """
-        parent = kwargs.pop("parent", None)
-        parentref = kwargs.pop("parentref", None)
-
-        self.logger.debug(
-            "Processor::_get_nodes_by_traversal:  TRAVERSING the tree at {}."
-            .format(parentref))
-
-        if data is None:
-            return
-
-        # Is there a next segment?
-        segments = yaml_path.escaped
-        if segment_index + 1 == len(segments):
-            # This traversal is gathering every leaf node
-            if isinstance(data, dict):
-                for val in data.values():
-                    for node_coord in self._get_nodes_by_traversal(
-                        val, yaml_path, segment_index,
-                        parent=parent, parentref=parentref
-                    ):
-                        self.logger.debug(
-                            "Processor::_get_nodes_by_traversal:  Yielding"
-                            " Hash value:")
-                        self.logger.debug(node_coord.node)
-                        yield node_coord
-            elif isinstance(data, list):
-                for ele in data:
-                    for node_coord in self._get_nodes_by_traversal(
-                        ele, yaml_path, segment_index,
-                        parent=parent, parentref=parentref
-                    ):
-                        self.logger.debug(
-                            "Processor::_get_nodes_by_traversal:  Yielding"
-                            " Array value:")
-                        self.logger.debug(node_coord.node)
-                        yield node_coord
-            else:
-                self.logger.debug(
-                    "Processor::_get_nodes_by_traversal:  Yielding Scalar"
-                    " value:")
-                self.logger.debug(data)
-                yield NodeCoords(data, parent, parentref)
-        else:
-            # There is a filter in the next segment
-            if isinstance(data, dict):
-                for key, val in data.items():
-                    # Depth-first expansion
-                    for node_coord in self._get_nodes_by_traversal(
-                        val, yaml_path, segment_index,
-                        parent=data, parentref=key
-                    ):
-                        self.logger.debug(
-                            "Processor::_get_nodes_by_traversal:  Yielding"
-                            " depth-first Hash value:")
-                        self.logger.debug(node_coord.node)
-                        yield node_coord
-
-                    # Find direct match
-                    for node_coord in self._get_nodes_by_path_segment(
-                        val, yaml_path, segment_index + 1, data, key
-                    ):
-                        self.logger.debug(
-                            "Processor::_get_nodes_by_traversal:  Yielding"
-                            " direct-match Hash value:")
-                        self.logger.debug(node_coord.node)
-                        yield node_coord
-            elif isinstance(data, list):
-                for idx, ele in enumerate(data):
-                    # Depth-first expansion
-                    for node_coord in self._get_nodes_by_traversal(
-                        ele, yaml_path, segment_index,
-                        parent=data, parentref=ele
-                    ):
-                        self.logger.debug(
-                            "Processor::_get_nodes_by_traversal:  Yielding"
-                            " depth-first Array value:")
-                        self.logger.debug(node_coord.node)
-                        yield node_coord
-
-                    # Find direct match
-                    for node_coord in self._get_nodes_by_path_segment(
-                        ele, yaml_path, segment_index + 1, data, idx
-                    ):
-                        self.logger.debug(
-                            "Processor::_get_nodes_by_traversal:  Yielding"
-                            " direct-match Array value:")
-                        self.logger.debug(node_coord.node)
-                        yield node_coord
-
     # pylint: disable=locally-disabled,too-many-branches,too-many-arguments
     def _get_nodes_by_path_segment(self, data: Any,
                                    yaml_path: YAMLPath, segment_index: int,
@@ -690,6 +581,115 @@ class Processor:
         # yield only when there are results
         if node_coords:
             yield node_coords
+
+    # pylint: disable=locally-disabled,too-many-branches
+    def _get_nodes_by_traversal(self, data: Any, yaml_path: YAMLPath,
+                                segment_index: int, **kwargs: Any
+                                ) -> Generator[Any, None, None]:
+        """
+        Deeply traverse the document tree, returning all or filtered nodes.
+
+        Parameters:
+        1. data (ruamel.yaml data) The parsed YAML data to process
+        2. yaml_path (yamlpath.Path) The YAML Path being processed
+        3. segment_index (int) Segment index of the YAML Path to process
+
+        Keyword Parameters:
+        * parent (ruamel.yaml node) The parent node from which this query
+          originates
+        * parentref (Any) The Index or Key of data within parent
+
+        Returns:  (Generator[Any, None, None]) Each node coordinate as they are
+        matched.
+        """
+        parent = kwargs.pop("parent", None)
+        parentref = kwargs.pop("parentref", None)
+
+        self.logger.debug(
+            "Processor::_get_nodes_by_traversal:  TRAVERSING the tree at {}."
+            .format(parentref))
+
+        if data is None:
+            return
+
+        # Is there a next segment?
+        segments = yaml_path.escaped
+        if segment_index + 1 == len(segments):
+            # This traversal is gathering every leaf node
+            if isinstance(data, dict):
+                for val in data.values():
+                    for node_coord in self._get_nodes_by_traversal(
+                        val, yaml_path, segment_index,
+                        parent=parent, parentref=parentref
+                    ):
+                        self.logger.debug(
+                            "Processor::_get_nodes_by_traversal:  Yielding"
+                            " Hash value:")
+                        self.logger.debug(node_coord.node)
+                        yield node_coord
+            elif isinstance(data, list):
+                for ele in data:
+                    for node_coord in self._get_nodes_by_traversal(
+                        ele, yaml_path, segment_index,
+                        parent=parent, parentref=parentref
+                    ):
+                        self.logger.debug(
+                            "Processor::_get_nodes_by_traversal:  Yielding"
+                            " Array value:")
+                        self.logger.debug(node_coord.node)
+                        yield node_coord
+            else:
+                self.logger.debug(
+                    "Processor::_get_nodes_by_traversal:  Yielding Scalar"
+                    " value:")
+                self.logger.debug(data)
+                yield NodeCoords(data, parent, parentref)
+        else:
+            # There is a filter in the next segment
+            if isinstance(data, dict):
+                for key, val in data.items():
+                    # Depth-first expansion
+                    for node_coord in self._get_nodes_by_traversal(
+                        val, yaml_path, segment_index,
+                        parent=data, parentref=key
+                    ):
+                        self.logger.debug(
+                            "Processor::_get_nodes_by_traversal:  Yielding"
+                            " depth-first Hash value:")
+                        self.logger.debug(node_coord.node)
+                        yield node_coord
+
+                    # Find direct match
+                    for node_coord in self._get_nodes_by_path_segment(
+                        val, yaml_path, segment_index + 1, data, key
+                    ):
+                        self.logger.debug(
+                            "Processor::_get_nodes_by_traversal:  Yielding"
+                            " direct-match Hash value:")
+                        self.logger.debug(node_coord.node)
+                        yield node_coord
+            elif isinstance(data, list):
+                for idx, ele in enumerate(data):
+                    # Depth-first expansion
+                    for node_coord in self._get_nodes_by_traversal(
+                        ele, yaml_path, segment_index,
+                        parent=data, parentref=ele
+                    ):
+                        self.logger.debug(
+                            "Processor::_get_nodes_by_traversal:  Yielding"
+                            " depth-first Array value:")
+                        self.logger.debug(node_coord.node)
+                        yield node_coord
+
+                    # Find direct match
+                    for node_coord in self._get_nodes_by_path_segment(
+                        ele, yaml_path, segment_index + 1, data, idx
+                    ):
+                        self.logger.debug(
+                            "Processor::_get_nodes_by_traversal:  Yielding"
+                            " direct-match Array value:")
+                        self.logger.debug(node_coord.node)
+                        yield node_coord
 
     def _get_required_nodes(self, data: Any, yaml_path: YAMLPath,
                             depth: int = 0, parent: Any = None,

--- a/yamlpath/processor.py
+++ b/yamlpath/processor.py
@@ -499,7 +499,7 @@ class Processor:
             if (matches and not invert) or (invert and not matches):
                 yield NodeCoords(data, parent, parentref)
 
-    # pylint: disable=locally-disabled,too-many-arguments
+    # pylint: disable=locally-disabled
     def _get_nodes_by_collector(
             self, data: Any, yaml_path: YAMLPath, segment_index: int,
             terms: CollectorTerms, **kwargs: Any
@@ -828,7 +828,7 @@ class Processor:
 
             yield NodeCoords(data, parent, parentref)
 
-    # pylint: disable=locally-disabled,too-many-statements,too-many-arguments
+    # pylint: disable=locally-disabled,too-many-statements
     def _get_optional_nodes(
             self, data: Any, yaml_path: YAMLPath, value: Any = None,
             depth: int = 0, **kwargs: Any

--- a/yamlpath/yamlpath.py
+++ b/yamlpath/yamlpath.py
@@ -753,6 +753,10 @@ class YAMLPath:
                 ppath += str(segment_attrs)
             elif segment_type == PathSegmentTypes.COLLECTOR:
                 ppath += str(segment_attrs)
+            elif segment_type == PathSegmentTypes.TRAVERSE:
+                if add_sep:
+                    ppath += pathsep
+                ppath += "**"
 
             add_sep = True
 

--- a/yamlpath/yamlpath.py
+++ b/yamlpath/yamlpath.py
@@ -696,7 +696,7 @@ class YAMLPath:
                 coal_value = None
             elif splat_count > 1:
                 # Multi-wildcard search
-                search_term = ""
+                search_term = "^"
                 was_splat = False
                 for char in segment_id:
                     if char == "*":
@@ -710,6 +710,7 @@ class YAMLPath:
                     else:
                         was_splat = False
                         search_term += char
+                search_term += "$"
 
                 coal_type = PathSegmentTypes.SEARCH
                 coal_value = SearchTerms(

--- a/yamlpath/yamlpath.py
+++ b/yamlpath/yamlpath.py
@@ -415,7 +415,8 @@ class YAMLPath:
                     # been identified as a special type, assume it is a KEY.
                     if segment_type is None:
                         segment_type = PathSegmentTypes.KEY
-                    path_segments.append((segment_type, segment_id))
+                    path_segments.append(self._expand_splats(
+                        yaml_path, segment_id, segment_type))
                     segment_id = ""
 
                 demarc_stack.append(char)
@@ -650,7 +651,7 @@ class YAMLPath:
         """
         if '*' in segment_id:
             splat_count = segment_id.count("*")
-            splat_pos = segment_id.index('*')
+            splat_pos = segment_id.index("*")
             segment_len = len(segment_id)
             if splat_count == 1:
                 if segment_len == 1:

--- a/yamlpath/yamlpath.py
+++ b/yamlpath/yamlpath.py
@@ -648,7 +648,18 @@ class YAMLPath:
     ) -> tuple:
         """
         Replace segment IDs with search operators when * is present.
+
+        Parameters:
+        1. yaml_path (str) The full YAML Path being processed.
+        2. segment_id (str) The segment identifier to parse.
+        3. segment_type (Optional[PathSegmentTypes]) Pending predetermined type
+           of the segment under evaluation.
+
+        Returns:  (tuple) Coallesced YAML Path segment.
         """
+        coal_type = segment_type
+        coal_value: Union[str, SearchTerms, None] = segment_id
+
         if '*' in segment_id:
             splat_count = segment_id.count("*")
             splat_pos = segment_id.index("*")
@@ -656,61 +667,55 @@ class YAMLPath:
             if splat_count == 1:
                 if segment_len == 1:
                     # /*/ -> [.!='']
-                    return (
-                        PathSegmentTypes.SEARCH,
-                        SearchTerms(True, PathSearchMethods.EQUALS, ".", "")
-                    )
-                if splat_pos == 0:
+                    coal_type = PathSegmentTypes.SEARCH
+                    coal_value = SearchTerms(
+                        True, PathSearchMethods.EQUALS, ".", "")
+                elif splat_pos == 0:
                     # /*text/ -> [.$text]
-                    return (
-                        PathSegmentTypes.SEARCH,
-                        SearchTerms(
-                            False, PathSearchMethods.ENDS_WITH, ".",
-                            segment_id[1:]))
-                if splat_pos == segment_len - 1:
+                    coal_type = PathSegmentTypes.SEARCH
+                    coal_value = SearchTerms(
+                        False, PathSearchMethods.ENDS_WITH, ".",
+                        segment_id[1:])
+                elif splat_pos == segment_len - 1:
                     # /text*/ -> [.^text]
-                    return (
-                        PathSegmentTypes.SEARCH,
-                        SearchTerms(
-                            False, PathSearchMethods.STARTS_WITH, ".",
-                            segment_id[0:splat_pos]))
-
-                # /te*xt/ -> [.=~/^te.*xt$/]
-                return (
-                    PathSegmentTypes.SEARCH,
-                    SearchTerms(
+                    coal_type = PathSegmentTypes.SEARCH
+                    coal_value = SearchTerms(
+                        False, PathSearchMethods.STARTS_WITH, ".",
+                        segment_id[0:splat_pos])
+                else:
+                    # /te*xt/ -> [.=~/^te.*xt$/]
+                    coal_type = PathSegmentTypes.SEARCH
+                    coal_value = SearchTerms(
                         False, PathSearchMethods.REGEX, ".",
                         "^{}.*{}$".format(
                             segment_id[0:splat_pos],
-                            segment_id[splat_pos + 1:])))
-
-            if splat_count == 2 and segment_len == 2:
+                            segment_id[splat_pos + 1:]))
+            elif splat_count == 2 and segment_len == 2:
                 # Traversal operator
-                return (PathSegmentTypes.TRAVERSE, None)
+                coal_type = PathSegmentTypes.TRAVERSE
+                coal_value = None
+            elif splat_count > 1:
+                # Multi-wildcard search
+                search_term = ""
+                was_splat = False
+                for char in segment_id:
+                    if char == "*":
+                        if was_splat:
+                            raise YAMLPathException(
+                                "The ** traversal operator has no meaning when"
+                                " combined with other characters", yaml_path,
+                                segment_id)
+                        was_splat = True
+                        search_term += ".*"
+                    else:
+                        was_splat = False
+                        search_term += char
 
-            search_term = ""
-            was_splat = False
-            for char in segment_id:
-                if char == "*":
-                    if was_splat:
-                        raise YAMLPathException(
-                            "The ** traversal operator has no meaning when"
-                            " combined with other characters", yaml_path,
-                            segment_id)
-                    was_splat = True
-                    search_term += ".*"
-                else:
-                    was_splat = False
-                    search_term += char
+                coal_type = PathSegmentTypes.SEARCH
+                coal_value = SearchTerms(
+                    False, PathSearchMethods.REGEX, ".", search_term)
 
-            return (
-                PathSegmentTypes.SEARCH,
-                SearchTerms(
-                    False, PathSearchMethods.REGEX, ".", search_term
-                )
-            )
-
-        return (segment_type, segment_id)
+        return (coal_type, coal_value)
 
     @classmethod
     def _stringify_yamlpath_segments(


### PR DESCRIPTION
Enhancements:
* Added a new YAML Path Segment Type:  *
  This is identical to a Search segment where the search term is `[.!=""]`.
  This translates to "match every Hash key for which its name is not empty and
  every Array element which is not empty".  This operator also vertically
  expands results from Collectors, effectively breaking them out from an Array-
  per-line to one-Scalar-per-line.  If you place this inside a Collector, the
  results will still be collected into an Array.
* The * character now also serves as a wildcard character for key-names, Hash
  values, and Array value comparisons, converting the segment to a Search.  For
  example, a YAML Path like `abc.d*` becomes `abc[.^d]`, `abc.*f` becomes
  `abc[.$f]`, and `abc.*e*` becomes `abc[.=~/^.*e.*$/], and so on.
* Added a new YAML Path Segment Type:  **
  This new type is a "Traversal" segment which causes YAML Path operations to
  deeply traverse the document from that point.  When there are no further
  segments in the YAML Path, every leaf node (Scalar value) is matched.  When
  the YAML Path has at least one further segment, it (and all further segments)
  must match subsequent nodes (anywhere deeper than that point in the document)
  or none are matched. Results can be collected.
* The yaml-merge and yaml-get command-line tools now treat the - pseudo-file as
  implicit when NOT specified AND the session is non-TTY.  This can be blocked
  with --nostdin|-S.  This enables, for example, piping into these commands
  without being forced to specify the - pseudo-file as an argument to them.
* The yaml-merge command now enables users to force the merged document to be
  written out as YAML, JSON via a new --document-format (-D) command-line
  argument.  When unset, the format will be that of the first document (AUTO).
* The yaml-merge command now accepts multi-document YAML files, created when
  the YAML standard-specified End-of-Document, Start-of-Document marker pair
  (...<EOL> followed by ---<EOL>) is present, like:
  ```yaml
  ---
  document: 1
  ...
  ---
  document: 2
  ```
* The yaml-merge command now accepts multi-document JSON files, created when
  there are multiple root-level entities, like:
  ```json
  {"document": 1}
  {"document": 2}
  ```
* Because any document to yaml-merge can be a multi-document, it no longer
  requires at least 2 YAML_FILEs be supplied on the command-line.  If users
  pass only a single file or stream that is not a multi-document file, its
  content will merely be written out without any merging into it.  This can be
  useful for trivially converting any file from YAML to JSON or JSON to YAML,
  like `yaml-merge --document-format=json file.yaml` or
  `yaml-merge --document-format=yaml file.json`.
* The `yaml-set` command-line tool can now write changes to minimally-viable
  files, enabling users to build up new data files from scratch.  The file must
  exist and have some minimum structure, depending on document type.  For
  example:
  A minimally-viable YAML file:
  ```yaml
  ---
  # The triple-dash is required.
  ```
  Two versions of a minimally-viable JSON file:
  ```json
  {}
  ```
  or:
  ```json
  []
  ```

Bug Fixes:
* Collectors were breaking search nodes with Regular Expressions, making it
  impossible for collected searches to return expected matches.
* Fixed the Known Issue which was logged at version 2.4.0; setting values which
  override aliased key-value pairs now correctly adds the new key-value pair to
  the DOM.
* When the left-most document was JSON, yaml-merge and yaml-set would both
  improperly write out a YAML document start mark (---) and then a hybrid
  JSON/YAML result rather than valid JSON.

Non-Breaking API Changes:
* The various protected _get_* methods of Processor were changed to reduce the
  number of positional parameters while also allowing for new special-use
  parameters for future changes.  The formerly optional positional `parent` and
  `parentref` parameters are now optional keyword arguments by the same names.
  Because these were all protected methods and the affected parameters were
  optional anyway, this is not deemed a breaking change; no one should have
  been directly calling them.
* The get_yaml_editor function now supports several keyword arguments which
  provide for some customization of the returned ruamel.yaml.YAML instance.
  See its documentation for details.  This is a non-breaking change as the
  defaults for each new keyword argument set the behavior identical to what it
  was before this change.
* The get_yaml_data function now returns False rather than None when there is
  an issue attempting to load data.  This is because an empty-but-viable
  document correctly returns None but there is no valid YAML or JSON document
  which can be comprised only of a Scalar Boolean.  This is a non-breaking
  change because None and False are equivalent for code like:
  ```python
  data = get_yaml_data(get_yaml_editor(), ConsoleLogger(), "file.yaml")
  if not data:
    print("No data")
  ```
  However, you can now differentiate between "No data" and "Invalid document"
  like so:
  ```python
  data = get_yaml_data(get_yaml_editor(), ConsoleLogger(), "file.yaml")
  if data is None:
    print("No data")
  elif not data:
    print("Invalid document")
  ```

To reflect these changes:
* eyaml-rotate-keys is now version 1.0.4
* yaml-get is now version 1.2.0
* yaml-merge is now version 0.1.0
* yaml-paths is now version 0.2.1
* yaml-set is now version 1.1.0
