### PR TITLE
Prep release 3.3.0

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -2,6 +2,8 @@
 engines:
   pylint:
     enabled: false
+  pylintpython3:
+    enabled: false
 
 exclude_paths:
   - 'tests/**'

--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -9,3 +9,4 @@ exclude_paths:
   - 'tests/**'
   - '**/*.md'
   - '**/__init__.py'
+  - 'README.md'

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,14 @@
 [run]
+# Trace partial-branches in code to ensure every line is executed
+branch = true
+
+# Enable multi-threaded processing of tests and coverage scanning
+parallel = true
+
+# Move .coverage and all temporary .coverage* files to a temporary directory
+data_file = /tmp/yamlpath-python-coverage-data
+
+# Ignore these files from coverage analysis
 omit =
 	# Don't bother with ruamel.yaml patches (not my code)
 	yamlpath/patches/emitter_write_folded_fix.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,4 @@
 [run]
-# Trace partial-branches in code to ensure every line is executed
-branch = true
-
 # Enable multi-threaded processing of tests and coverage scanning
 parallel = true
 

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ venv*.bak/
 
 # IDE configurations
 .vscode/
+.vscode-env*/
+.vscode-venv*/
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ python:
   - 3.8
 
 install:
-  - pip install --upgrade mypy pytest pytest-cov pytest-console-scripts pylint coveralls pep257
+  - pip install --upgrade setuptools mypy pytest pytest-cov pytest-console-scripts pylint coveralls pep257
   - gem install hiera-eyaml -v 2.1.0
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-dist: xenial
-os: linux
-
 language:
   - python
 
@@ -8,6 +5,10 @@ python:
   - 3.6
   - 3.7
   - 3.8
+
+os:
+  - linux
+  - windows
 
 install:
   - pip install --upgrade setuptools mypy pytest pytest-cov pytest-console-scripts pylint coveralls pep257

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,8 @@ python:
   - 3.7
   - 3.8
 
-os:
-  - linux
-  - windows
+os: linux
+dist: xenial
 
 install:
   - pip install --upgrade setuptools mypy pytest pytest-cov pytest-console-scripts pylint coveralls pep257

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,13 @@ os: linux
 dist: xenial
 
 install:
-  - pip install --upgrade setuptools mypy pytest pytest-cov pytest-console-scripts pylint coveralls pep257
+  - python -m pip install --upgrade pip
+  - pip install --upgrade setuptools
+  - pip install .
+  - pip install --upgrade mypy pytest pytest-cov pytest-console-scripts pylint coveralls pep257
   - gem install hiera-eyaml -v 2.1.0
 
 script:
-  - pip install .
   - pep257 yamlpath
   - mypy yamlpath
   - pylint yamlpath

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: false
+dist: xenial
+os: linux
 
 language:
   - python
@@ -22,7 +23,7 @@ script:
 
 deploy:
   provider: pypi
-  user: wwkimball
+  username: wwkimball
   password:
     secure: "cBWRVvQibxw2KTYJoruKeOA1vNDk2+ZuZsAzW9hq3bk2Ab4GDy7G8pYRhVhiHNMDY0w5+Ii66/i0ERpBC95bi7Mzy/NOzbhoYflr+lDOoC6YR76VpCyHJQ/I3YmyTjSeWqB86JLfmQNi9RJWBbZYWpsCuEjBRP7w6oOf2QdAefQUctJ9g69Gt5r7okNm4nfbiAwvUAjGBT7dSRKPrMmRhP8Qc5ugXrO3xNnh9xCBqBkvXfDQjlA3YCi3RiuWJQHkwIhHjfwoDXzis4bprBQUOAZ/+c6WiCvEsMsG1551Ilt7Q1x6aiu98m4hYkZMTIl5IjCMSXbnlOSdlv0XvO8jSq/+GGSdI6EbLAYC1MTnob7w1/NQSsVfz6dKl/pMCRC2J+OGNqv5a3Ln3rzeOTs9opZunHQ34Ro+MxEKSf+XdU48YJR1DlDLWYV9tbiVFG+tSybu3uxcs825EB4aNzL7pMBaIzMpEjhsDNEDZ90T6jDnLzJHYFgH3yj9ortpjYI3CZdvzsVqQrTT1zXzKzMbW6/o0U8azzGQWu24Bn6HSe3Cr0PQQpalSyN/usZziBwLYVj42d3tCtg1xGNUvzgX1mRst8Ltsag4g4OG54IJ4RihcviQWLY6Jgjnob5KU3JcCYzKJjKu5cXyuK2ec7lMCBRaVo6qaiP1iVPNLpXsqz4="
   skip_existing: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,11 @@ python:
   - 3.8
 
 install:
-  - pip install --upgrade ruamel.yaml mypy pytest pytest-cov pytest-console-scripts pylint coveralls pep257
+  - pip install --upgrade mypy pytest pytest-cov pytest-console-scripts pylint coveralls pep257
   - gem install hiera-eyaml -v 2.1.0
 
 script:
-  - pip install -e .
+  - pip install .
   - pep257 yamlpath
   - mypy yamlpath
   - pylint yamlpath

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ python:
 os: linux
 dist: xenial
 
+# Note:  pytest-cov requires the module to be installed with --editable lest it
+# will not cover all code-paths!
 install:
   - python -m pip install --upgrade pip
   - pip install --upgrade setuptools

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ dist: xenial
 install:
   - python -m pip install --upgrade pip
   - pip install --upgrade setuptools
-  - pip install .
+  - pip install --editable .
   - pip install --upgrade mypy pytest pytest-cov pytest-console-scripts pylint coveralls pep257
   - gem install hiera-eyaml -v 2.1.0
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,9 @@
 3.3.0:
+Bug Fixes:
+* It was impossible to install yamlpath 3.x without first installing
+  ruamel.yaml via pip for Python 3.x.  Not only has this been fixed but
+  explicit tests have been created to ensure this never happens again.
+
 Enhancements:
 * A new command-line tool, yaml-diff, now compares exactly two
   YAML/JSON/Compatible documents, producing a GNU diff-like report of any

--- a/CHANGES
+++ b/CHANGES
@@ -3,7 +3,7 @@ Enhancements:
 * A new command-line tool, yaml-diff, now compares exactly two
   YAML/JSON/Compatible documents, producing a GNU diff-like report of any
   differences in the data they present to parsers.  Along with diff's "a"
-  (add), "c" (change), and "d" (deleted) report entries, affected YAML Paths
+  (added), "c" (changed), and "d" (deleted) report entries, affected YAML Paths
   are printed in lieu of line numbers.  Further, a report entry of "s" (same)
   is available and can be enabled via command-line options.  This tool also
   features optional special handling of Arrays and Arrays-of-Hashes.

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,13 @@
+3.3.0:
+Enhancements:
+* A new command-line tool, yaml-diff, now compares exactly two
+  YAML/JSON/Compatible documents, producing a GNU diff-like report of any
+  differences in the data they present to parsers.  Along with diff's "a"
+  (add), "c" (change), and "d" (deleted) report entries, affected YAML Paths
+  are printed in lieu of line numbers.  Further, a report entry of "s" (same)
+  is available and can be enabled via command-line options.  This tool also
+  features optional special handling of Arrays and Arrays-of-Hashes.
+
 3.2.0:
 Enhancements:
 * Expanded YAML Path Search Expressions such that the OPERAND of a Search

--- a/CHANGES
+++ b/CHANGES
@@ -6,7 +6,9 @@ Enhancements:
   (added), "c" (changed), and "d" (deleted) report entries, affected YAML Paths
   are printed in lieu of line numbers.  Further, a report entry of "s" (same)
   is available and can be enabled via command-line options.  This tool also
-  features optional special handling of Arrays and Arrays-of-Hashes.
+  features optional special handling of Arrays and Arrays-of-Hashes, which can
+  be configured as CLI options or via an INI file for distinct settings per
+  YAML Path.  See --help or the Wiki for more detail.
 
 3.2.0:
 Enhancements:

--- a/CHANGES
+++ b/CHANGES
@@ -19,6 +19,13 @@ API Changes:
   nested, this will be a bare list index.  Any NodeCoords in the virtual
   container which point to real nodes in the DOM will have their own concrete
   YAML Paths.
+* YAMLPath instances now support nonmutating addition of individual segments
+  via the + operator.  Whereas the append() method mutates the YAMLPath being
+  acted upon, + creates a new YAMLPath that is the original plus the new
+  segment.  In both cases, the orignal YAMLPath's seperator is retained during
+  both operations.  As with .append(), new segments added via + must also be
+  properly escaped -- typically via path.escape_path_section -- before being
+  added.
 
 3.2.0:
 Enhancements:

--- a/CHANGES
+++ b/CHANGES
@@ -10,6 +10,16 @@ Enhancements:
   be configured as CLI options or via an INI file for distinct settings per
   YAML Path.  See --help or the Wiki for more detail.
 
+API Changes:
+* NodeCoords now employ a new `path` attribute.  This is an optional parameter
+  which is assigned during construction to later report the translated origin
+  YAML Path; this is where the node was found or created within the DOM.  Note
+  that Collector segments work against virtual DOMs, so the YAML Path of an
+  outer Collector will be virtual, relative to its parent at construction; when
+  nested, this will be a bare list index.  Any NodeCoords in the virtual
+  container which point to real nodes in the DOM will have their own concrete
+  YAML Paths.
+
 3.2.0:
 Enhancements:
 * Expanded YAML Path Search Expressions such that the OPERAND of a Search

--- a/README.md
+++ b/README.md
@@ -30,11 +30,12 @@ for other projects to readily employ YAML Paths.
 7. [Basic Usage](#basic-usage)
    1. [Basic Usage:  Command-Line Tools](#basic-usage--command-line-tools)
       1. [Rotate Your EYAML Keys](#rotate-your-eyaml-keys)
-      2. [Get a YAML/JSON/Compatible Value](#get-a-yamljsoncompatible-value)
-      3. [Search For YAML Paths](#search-for-yaml-paths)
-      4. [Change a YAML/JSON/Compatible Value](#change-a-yamljsoncompatible-value)
-      5. [Merge YAML/JSON/Compatible Files](#merge-yamljsoncompatible-files)
-      6. [Validate YAML/JSON/Compatible Documents](#validate-yamljsoncompatible-documents)
+      2. [Get the Differences Between Two Documents](#get-the-differences-between-two-documents)
+      3. [Get a YAML/JSON/Compatible Value](#get-a-yamljsoncompatible-value)
+      4. [Search For YAML Paths](#search-for-yaml-paths)
+      5. [Change a YAML/JSON/Compatible Value](#change-a-yamljsoncompatible-value)
+      6. [Merge YAML/JSON/Compatible Files](#merge-yamljsoncompatible-files)
+      7. [Validate YAML/JSON/Compatible Documents](#validate-yamljsoncompatible-documents)
    2. [Basic Usage:  Libraries](#basic-usage--libraries)
       1. [Initialize ruamel.yaml and These Helpers](#initialize-ruamelyaml-and-these-helpers)
       2. [Searching for YAML Nodes](#searching-for-yaml-nodes)
@@ -343,6 +344,63 @@ EYAML_KEYS:
 
 Any YAML_FILEs lacking EYAML values will not be modified (or backed up, even
 when -b/--backup is specified).
+```
+
+* [yaml-diff](yamlpath/commands/yaml_diff.py)
+
+```text
+usage: yaml-diff [-h] [-V] [-a] [-s | -o]
+                 [-t ['.', '/', 'auto', 'dot', 'fslash']] [-x EYAML]
+                 [-r PRIVATEKEY] [-u PUBLICKEY] [-E] [-d | -v | -q]
+                 YAML_FILE YAML_FILE
+
+Calculate the functional difference between two YAML/JSON/Compatible
+documents. Immaterial differences (which YAML/JSON parsers discard) are
+ignored. EYAML can be employed to compare encrypted values.
+
+positional arguments:
+  YAML_FILE             exactly two YAML/JSON/compatible files to compare; use
+                        - to read one document from STDIN
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -V, --version         show program's version number and exit
+  -a, --sync-arrays     Synchronize array elements before comparing them,
+                        resulting only in ADD, DELETE, and SAME differences
+                        (no CHANGEs because the positions of elements are
+                        disregarded); Array-of-Hash elements must completely
+                        and perfectly match or they will be deemed additions
+                        or deletions
+  -s, --same            Show all nodes which are the same in addition to
+                        differences
+  -o, --onlysame        Show only nodes which are the same, still reporting
+                        that differences exist -- when they do -- with an
+                        exit-state of 1
+  -t ['.', '/', 'auto', 'dot', 'fslash'], --pathsep ['.', '/', 'auto', 'dot', 'fslash']
+                        indicate which YAML Path seperator to use when
+                        rendering results; default=dot
+  -d, --debug           output debugging details
+  -v, --verbose         increase output verbosity
+  -q, --quiet           suppress all output except system errors
+
+EYAML options:
+  Left unset, the EYAML keys will default to your system or user defaults.
+  Both keys must be set either here or in your system or user EYAML
+  configuration file when using EYAML.
+
+  -x EYAML, --eyaml EYAML
+                        the eyaml binary to use when it isn't on the PATH
+  -r PRIVATEKEY, --privatekey PRIVATEKEY
+                        EYAML private key
+  -u PUBLICKEY, --publickey PUBLICKEY
+                        EYAML public key
+  -E, --ignore-eyaml-values
+                        Do not use EYAML to compare encrypted data; rather,
+                        treat ENC[...] values as regular strings
+
+Only one YAML_FILE may be the - pseudo-file for reading from STDIN. For more
+information about YAML Paths, please visit
+https://github.com/wwkimball/yamlpath.
 ```
 
 * [yaml-get](yamlpath/commands/yaml_get.py)
@@ -748,6 +806,43 @@ re-encrypt your data with the replacement certificates, hiera-eyaml 3.x will
 fail to decrypt your data!**  This is *not* a problem with YAML Path.
 hiera-eyaml certificate compatibility is well outside the purview of YAML Path
 and its tools.
+
+#### Get the Differences Between Two Documents
+
+For routine use:
+
+```shell
+yaml-diff yaml_file1.yaml yaml_file2.yaml
+```
+
+Output is very similar to that of standard GNU diff against text files, except
+it is generated against the *data* within the input files.  This excludes
+evaluating purely structural and immaterial differences between them like value
+demarcation, white-space, and comments.  When you need to evaluate the two
+files as if they were just text files, use GNU diff or any of its clones.
+
+To see all identical entries along with differences:
+
+```shell
+yaml-diff --same yaml_file1.yaml yaml_file2.yaml
+```
+
+To see *only* entries which are identical between the documents:
+
+```shell
+yaml-diff --onlysame yaml_file1.yaml yaml_file2.yaml
+```
+
+Advanced:  Arrays can be evaluated such that they are synchronized before
+evaluation.  Rather than compare elements by identical index in both
+documents -- reporting differences between them as changes and any additional
+elements as additions or deletions -- they can instead be compared by matching
+up all identical elements and then reporting only those values which are unique
+to either document (and optionally identical matches).
+
+```shell
+yaml-diff --sync-arrays yaml_file1.yaml yaml_file2.yaml
+```
 
 #### Get a YAML/JSON/Compatible Value
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ for other projects to readily employ YAML Paths.
       5. [Change a YAML/JSON/Compatible Value](#change-a-yamljsoncompatible-value)
       6. [Merge YAML/JSON/Compatible Files](#merge-yamljsoncompatible-files)
       7. [Validate YAML/JSON/Compatible Documents](#validate-yamljsoncompatible-documents)
+
    2. [Basic Usage:  Libraries](#basic-usage--libraries)
       1. [Initialize ruamel.yaml and These Helpers](#initialize-ruamelyaml-and-these-helpers)
       2. [Searching for YAML Nodes](#searching-for-yaml-nodes)

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -52,7 +52,7 @@ ForEach ($EnvDir in $EnvDirs) {
     pip install -e .
     if (!$?) {
         & deactivate
-        Remove-Item $TmpVEnv
+        Remove-Item -Recurse -Force $TmpVEnv
         Write-Error "`nERROR:  Unable to install self!"
         exit 124
     }
@@ -64,7 +64,7 @@ ForEach ($EnvDir in $EnvDirs) {
     pep257 yamlpath | Out-String
     if (!$?) {
         & deactivate
-        Remove-Item $TmpVEnv
+        Remove-Item -Recurse -Force $TmpVEnv
         Write-Error "PEP257 Error: $?"
         exit 9
     }
@@ -73,7 +73,7 @@ ForEach ($EnvDir in $EnvDirs) {
     mypy yamlpath | Out-String
     if (!$?) {
         & deactivate
-        Remove-Item $TmpVEnv
+        Remove-Item -Recurse -Force $TmpVEnv
         Write-Error "MYPY Error: $?"
         exit 10
     }
@@ -82,7 +82,7 @@ ForEach ($EnvDir in $EnvDirs) {
     pylint yamlpath | Out-String
     if (!$?) {
         & deactivate
-        Remove-Item $TmpVEnv
+        Remove-Item -Recurse -Force $TmpVEnv
         Write-Error "PYLINT Error: $?"
         exit 11
     }
@@ -91,14 +91,12 @@ ForEach ($EnvDir in $EnvDirs) {
     pytest -vv --cov=yamlpath --cov-report=term-missing --cov-fail-under=100 --script-launch-mode=subprocess tests
     if (!$?) {
         & deactivate
-        Remove-Item $TmpVEnv
+        Remove-Item -Recurse -Force $TmpVEnv
         Write-Error "PYTEST Error: $?"
         exit 12
     }
 
+    Write-Output "Deactivating virtual Python environment..."
     & deactivate
-    Remove-Item $TmpVEnv
+    Remove-Item -Recurse -Force $TmpVEnv
 }
-
-Write-Output "Deactivating virtual Python environment..."
-& deactivate

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -48,6 +48,9 @@ ForEach ($EnvDir in $EnvDirs) {
     Write-Output "...upgrading pip"
     python -m pip install --upgrade pip
 
+    Write-Output "...upgrading setuptools"
+    pip install --upgrade setuptools
+
     Write-Output "...installing self"
     pip install -e .
     if (!$?) {

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -7,6 +7,7 @@ if (-Not $HasTestsDir -Or -Not $HasProjectDir) {
 
 # Credit: https://stackoverflow.com/a/54935264
 function New-TemporaryDirectory {
+    [CmdletBinding(SupportsShouldProcess = $true)]
     $parent = [System.IO.Path]::GetTempPath()
     do {
         $name = [System.IO.Path]::GetRandomFileName()

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -12,7 +12,7 @@ function New-TemporaryDirectory {
         $name = [System.IO.Path]::GetRandomFileName()
         $item = New-Item -Path $parent -Name $name -ItemType "directory" -ErrorAction SilentlyContinue
     } while (-not $item)
-    return $Item.FullName
+    return $Item
 }
 
 $EnvDirs = Get-ChildItem -Directory -Filter "env*"

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -8,6 +8,7 @@ if (-Not $HasTestsDir -Or -Not $HasProjectDir) {
 # Credit: https://stackoverflow.com/a/54935264
 function New-TemporaryDirectory {
     [CmdletBinding(SupportsShouldProcess = $true)]
+    param()
     $parent = [System.IO.Path]::GetTempPath()
     do {
         $name = [System.IO.Path]::GetRandomFileName()

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -7,6 +7,12 @@ if ! [ -d tests -a -d yamlpath ]; then
 	exit 2
 fi
 
+# Delete all cached data
+find ./ -type d -name '__pycache__' -delete
+rm -rf yamlpath.egg-info
+rm -rf /tmp/yamlpath-python-coverage-data
+rm -f .coverage
+
 for envDir in env* venv*; do
 	deactivate &>/dev/null
 	if ! source "${envDir}/bin/activate"; then

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -38,6 +38,9 @@ EOF
 	echo "...upgrading pip"
 	python -m pip install --upgrade pip >/dev/null
 
+	echo "...upgrading setuptools"
+	pip install --upgrade setuptools >/dev/null
+
 	echo "...installing self"
 	if ! pip install -e . >/dev/null; then
 		deactivate

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -79,7 +79,7 @@ EOF
 
 	echo -e "\nPYTEST..."
 	if ! pytest \
-		-vv \
+		--verbose \
 		--cov=yamlpath \
 		--cov-report=term-missing \
 		--cov-fail-under=100 \

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+version = attr: yamlpath.__version__

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setuptools.setup(
     name="yamlpath",
     version=YAMLPATH_VERSION,
     description=(
-        "Command-line get/set/merge/validate/scan/convert processors for"
+        "Command-line get/set/merge/validate/scan/convert/diff processors for"
         + " YAML/JSON/Compatible data using powerful, intuitive, command-line"
         + " friendly syntax"),
     long_description=long_description,
@@ -37,6 +37,7 @@ setuptools.setup(
             "yaml-set = yamlpath.commands.yaml_set:main",
             "yaml-merge = yamlpath.commands.yaml_merge:main",
             "yaml-validate = yamlpath.commands.yaml_validate:main",
+            "yaml-diff = yamlpath.commands.yaml_diff:main",
         ]
     },
     python_requires=">3.6.0",

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,31 @@
-import setuptools
-
-from yamlpath.common import YAMLPATH_VERSION
+"""Build this project."""
+import codecs
+import os.path
+from setuptools import find_packages, setup
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-setuptools.setup(
+# Centralized module versioning is based on:
+# https://packaging.python.org/guides/single-sourcing-package-version/
+def read(rel_path):
+    """Read a file with inferred codec."""
+    here = os.path.abspath(os.path.dirname(__file__))
+    with codecs.open(os.path.join(here, rel_path), 'r') as fhnd:
+        return fhnd.read()
+
+def get_version(rel_path):
+    """Get the value of __version__ from any file."""
+    for line in read(rel_path).splitlines():
+        if line.startswith('__version__'):
+            delim = '"' if '"' in line else "'"
+            return line.split(delim)[1]
+    raise RuntimeError(
+        "Unable to find __version__ string in {}.".format(rel_path))
+
+setup(
     name="yamlpath",
-    version=YAMLPATH_VERSION,
+    version=get_version("yamlpath/__init__.py"),
     description=(
         "Command-line get/set/merge/validate/scan/convert/diff processors for"
         + " YAML/JSON/Compatible data using powerful, intuitive, command-line"
@@ -27,8 +45,8 @@ setuptools.setup(
     author="William W. Kimball, Jr., MBA, MSIS",
     author_email="github-yamlpath@kimballstuff.com",
     license="ISC",
-    keywords="yaml eyaml json yaml-path",
-    packages=setuptools.find_packages(),
+    keywords="yaml eyaml json yaml-path diff merge",
+    packages=find_packages(),
     entry_points={
         "console_scripts": [
             "eyaml-rotate-keys = yamlpath.commands.eyaml_rotate_keys:main",

--- a/setup.py
+++ b/setup.py
@@ -1,31 +1,11 @@
 """Build this project."""
-import codecs
-import os.path
 from setuptools import find_packages, setup
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-# Centralized module versioning is based on:
-# https://packaging.python.org/guides/single-sourcing-package-version/
-def read(rel_path):
-    """Read a file with inferred codec."""
-    here = os.path.abspath(os.path.dirname(__file__))
-    with codecs.open(os.path.join(here, rel_path), 'r') as fhnd:
-        return fhnd.read()
-
-def get_version(rel_path):
-    """Get the value of __version__ from any file."""
-    for line in read(rel_path).splitlines():
-        if line.startswith('__version__'):
-            delim = '"' if '"' in line else "'"
-            return line.split(delim)[1]
-    raise RuntimeError(
-        "Unable to find __version__ string in {}.".format(rel_path))
-
 setup(
     name="yamlpath",
-    version=get_version("yamlpath/__init__.py"),
     description=(
         "Command-line get/set/merge/validate/scan/convert/diff processors for"
         + " YAML/JSON/Compatible data using powerful, intuitive, command-line"

--- a/tests/test_commands_yaml_diff.py
+++ b/tests/test_commands_yaml_diff.py
@@ -1,0 +1,1270 @@
+import pytest
+
+from tests.conftest import create_temp_yaml_file, requireseyaml, old_eyaml_keys
+
+
+class Test_commands_yaml_diff():
+    """Tests for the yaml-diff command-line tool."""
+    command = "yaml-diff"
+
+    lhs_hash_content = """---
+key: value
+array:
+  - 1
+  - 2
+  - 3
+aoh:
+  - id: 0
+    name: zero
+  - id: 1
+    name: one
+  - id: 2
+    name: two
+lhs_exclusive:
+  - node
+"""
+
+    lhs_array_content = """---
+- step: 1
+  action: input
+  args:
+    - world
+- step: 2
+  action: print
+  message: Hello, %args[0]!
+- step: 3
+  action: quit
+  status: 0
+"""
+
+    rhs_hash_content = """---
+key: different value
+array:
+  - 1
+  - 3
+  - 4 (new)
+  - 5 (new)
+aoh:
+  - id: 0
+    name: zero
+    extra_field: is an extra field (new)
+  - id: 1
+    name: different one
+  - id: 3 (new)
+    name: three (new)
+  - id: 4 (new)
+    name: four (new)
+rhs_exclusive:
+  with:
+    structure: true
+"""
+
+    rhs_array_content = """---
+- step: 1
+  action: input
+  args:
+    - le monde
+- step: 2
+  action: print
+  message: A tout %args[0]!
+"""
+
+    standard_hash_diff = """c key
+< value
+---
+> different value
+
+c array[1]
+< 2
+---
+> 3
+
+c array[2]
+< 3
+---
+> 4 (new)
+
+a array[3]
+> 5 (new)
+
+a aoh[0].extra_field
+> is an extra field (new)
+
+c aoh[1].name
+< one
+---
+> different one
+
+c aoh[2].id
+< 2
+---
+> 3 (new)
+
+c aoh[2].name
+< two
+---
+> three (new)
+
+d lhs_exclusive
+< ["node"]
+
+a aoh[3]
+> {"id": "4 (new)", "name": "four (new)"}
+
+a rhs_exclusive
+> {"with": {"structure": true}}
+"""
+
+    standard_array_diff = """c [0].args[0]
+< world
+---
+> le monde
+
+c [1].message
+< Hello, %args[0]!
+---
+> A tout %args[0]!
+
+d [2]
+< {"step": 3, "action": "quit", "status": 0}
+"""
+
+    def test_no_options(self, script_runner):
+        result = script_runner.run(self.command)
+        assert not result.success, result.stderr
+        assert "the following arguments are required: YAML_FILE" in result.stderr
+
+    def test_too_many_pseudo_files(self, script_runner):
+        result = script_runner.run(self.command, "-", "-")
+        assert not result.success, result.stderr
+        assert "Only one YAML_FILE may be the - pseudo-file" in result.stderr
+
+    def test_missing_first_input_file_arg(self, script_runner):
+        result = script_runner.run(self.command, "no-file.yaml", "no-file.yaml")
+        assert not result.success, result.stderr
+        assert "File not found" in result.stderr
+
+    def test_missing_second_input_file_arg(self, script_runner, tmp_path_factory):
+        lhs_file = create_temp_yaml_file(tmp_path_factory, self.lhs_hash_content)
+        result = script_runner.run(self.command, lhs_file, "no-file.yaml")
+        assert not result.success, result.stderr
+        assert "File not found" in result.stderr
+
+    def test_bad_eyaml_value(self, script_runner, tmp_path_factory):
+        content = """---
+        aliases:
+          - &encryptedScalar >
+            ENC[PKCS7,MIIx...broken-on-purpose...==]
+        """
+        yaml_file = create_temp_yaml_file(tmp_path_factory, content)
+        result = script_runner.run(
+            self.command,
+            "--eyaml=/does/not/exist-on-most/systems",
+            yaml_file,
+            yaml_file
+        )
+        assert not result.success, result.stderr
+        assert "No accessible eyaml command" in result.stderr
+
+    def test_no_diff_two_hash_files(self, script_runner, tmp_path_factory):
+        lhs_file = create_temp_yaml_file(tmp_path_factory, self.lhs_hash_content)
+        rhs_file = create_temp_yaml_file(tmp_path_factory, self.lhs_hash_content)
+
+        # DEBUG
+        # print("LHS File:  {}".format(lhs_file))
+        # print("RHS File:  {}".format(rhs_file))
+        # print("Expected Output:")
+        # print(merged_yaml_content)
+
+        result = script_runner.run(
+            self.command
+            , lhs_file
+            , rhs_file)
+        assert result.success, result.stderr
+        assert "" == result.stdout
+
+    def test_no_diff_two_array_files(self, script_runner, tmp_path_factory):
+        lhs_file = create_temp_yaml_file(tmp_path_factory, self.lhs_array_content)
+        rhs_file = create_temp_yaml_file(tmp_path_factory, self.lhs_array_content)
+
+        # DEBUG
+        # print("LHS File:  {}".format(lhs_file))
+        # print("RHS File:  {}".format(rhs_file))
+        # print("Expected Output:")
+        # print(merged_yaml_content)
+
+        result = script_runner.run(
+            self.command
+            , lhs_file
+            , rhs_file)
+        assert result.success, result.stderr
+        assert "" == result.stdout
+
+    def test_no_hash_diff_lhs_from_stdin(self, script_runner, tmp_path_factory):
+        import subprocess
+        rhs_file = create_temp_yaml_file(tmp_path_factory, self.lhs_hash_content)
+
+        # DEBUG
+        # print("LHS File:  {}".format(lhs_file))
+        # print("RHS File:  {}".format(rhs_file))
+        # print("Expected Output:")
+        # print(merged_yaml_content)
+
+        result = subprocess.run(
+            [self.command
+            , "-"
+            , rhs_file
+            ]
+            , stdout=subprocess.PIPE
+            , input=self.lhs_hash_content
+            , universal_newlines=True
+        )
+        assert 0 == result.returncode, result.stderr
+        assert "" == result.stdout
+
+    def test_no_array_diff_lhs_from_stdin(self, script_runner, tmp_path_factory):
+        import subprocess
+        rhs_file = create_temp_yaml_file(tmp_path_factory, self.lhs_array_content)
+
+        # DEBUG
+        # print("LHS File:  {}".format(lhs_file))
+        # print("RHS File:  {}".format(rhs_file))
+        # print("Expected Output:")
+        # print(merged_yaml_content)
+
+        result = subprocess.run(
+            [self.command
+            , "-"
+            , rhs_file
+            ]
+            , stdout=subprocess.PIPE
+            , input=self.lhs_array_content
+            , universal_newlines=True
+        )
+        assert 0 == result.returncode, result.stderr
+        assert "" == result.stdout
+
+    def test_no_hash_diff_rhs_from_stdin(self, script_runner, tmp_path_factory):
+        import subprocess
+        lhs_file = create_temp_yaml_file(tmp_path_factory, self.rhs_hash_content)
+
+        # DEBUG
+        # print("LHS File:  {}".format(lhs_file))
+        # print("RHS File:  {}".format(rhs_file))
+        # print("Expected Output:")
+        # print(merged_yaml_content)
+
+        result = subprocess.run(
+            [self.command
+            , lhs_file
+            , "-"
+            ]
+            , stdout=subprocess.PIPE
+            , input=self.rhs_hash_content
+            , universal_newlines=True
+        )
+        assert 0 == result.returncode, result.stderr
+        assert "" == result.stdout
+
+    def test_no_array_diff_rhs_from_stdin(self, script_runner, tmp_path_factory):
+        import subprocess
+        lhs_file = create_temp_yaml_file(tmp_path_factory, self.rhs_array_content)
+
+        # DEBUG
+        # print("LHS File:  {}".format(lhs_file))
+        # print("RHS File:  {}".format(rhs_file))
+        # print("Expected Output:")
+        # print(merged_yaml_content)
+
+        result = subprocess.run(
+            [self.command
+            , lhs_file
+            , "-"
+            ]
+            , stdout=subprocess.PIPE
+            , input=self.rhs_array_content
+            , universal_newlines=True
+        )
+        assert 0 == result.returncode, result.stderr
+        assert "" == result.stdout
+
+    def test_simple_diff_two_hash_files(self, script_runner, tmp_path_factory):
+        lhs_file = create_temp_yaml_file(tmp_path_factory, self.lhs_hash_content)
+        rhs_file = create_temp_yaml_file(tmp_path_factory, self.rhs_hash_content)
+
+        # DEBUG
+        # print("LHS File:  {}".format(lhs_file))
+        # print("RHS File:  {}".format(rhs_file))
+        # print("Expected Output:")
+        # print(merged_yaml_content)
+
+        result = script_runner.run(
+            self.command
+            , lhs_file
+            , rhs_file)
+        assert not result.success, result.stderr
+        assert self.standard_hash_diff == result.stdout
+
+    def test_simple_diff_two_array_files(self, script_runner, tmp_path_factory):
+        lhs_file = create_temp_yaml_file(tmp_path_factory, self.lhs_array_content)
+        rhs_file = create_temp_yaml_file(tmp_path_factory, self.rhs_array_content)
+
+        # DEBUG
+        # print("LHS File:  {}".format(lhs_file))
+        # print("RHS File:  {}".format(rhs_file))
+        # print("Expected Output:")
+        # print(merged_yaml_content)
+
+        result = script_runner.run(
+            self.command
+            , lhs_file
+            , rhs_file)
+        assert not result.success, result.stderr
+        assert self.standard_array_diff == result.stdout
+
+    def test_simple_hash_diff_lhs_from_stdin(self, script_runner, tmp_path_factory):
+        import subprocess
+        rhs_file = create_temp_yaml_file(tmp_path_factory, self.rhs_hash_content)
+
+        result = subprocess.run(
+            [self.command
+            , "-"
+            , rhs_file
+            ]
+            , stdout=subprocess.PIPE
+            , input=self.lhs_hash_content
+            , universal_newlines=True
+        )
+        assert 1 == result.returncode, result.stderr
+        assert self.standard_hash_diff == result.stdout
+
+    def test_simple_array_diff_lhs_from_stdin(self, script_runner, tmp_path_factory):
+        import subprocess
+        rhs_file = create_temp_yaml_file(tmp_path_factory, self.rhs_array_content)
+
+        result = subprocess.run(
+            [self.command
+            , "-"
+            , rhs_file
+            ]
+            , stdout=subprocess.PIPE
+            , input=self.lhs_array_content
+            , universal_newlines=True
+        )
+        assert 1 == result.returncode, result.stderr
+        assert self.standard_array_diff == result.stdout
+
+    def test_simple_hash_diff_rhs_from_stdin(self, script_runner, tmp_path_factory):
+        import subprocess
+        lhs_file = create_temp_yaml_file(tmp_path_factory, self.lhs_hash_content)
+
+        result = subprocess.run(
+            [self.command
+            , lhs_file
+            , "-"
+            ]
+            , stdout=subprocess.PIPE
+            , input=self.rhs_hash_content
+            , universal_newlines=True
+        )
+        assert 1 == result.returncode, result.stderr
+        assert self.standard_hash_diff == result.stdout
+
+    def test_simple_array_diff_rhs_from_stdin(self, script_runner, tmp_path_factory):
+        import subprocess
+        lhs_file = create_temp_yaml_file(tmp_path_factory, self.lhs_array_content)
+
+        result = subprocess.run(
+            [self.command
+            , lhs_file
+            , "-"
+            ]
+            , stdout=subprocess.PIPE
+            , input=self.rhs_array_content
+            , universal_newlines=True
+        )
+        assert 1 == result.returncode, result.stderr
+        assert self.standard_array_diff == result.stdout
+
+    def test_simple_diff_hash_from_nothing_via_stdin(self, script_runner, tmp_path_factory):
+        import subprocess
+        rhs_file = create_temp_yaml_file(tmp_path_factory, self.rhs_hash_content)
+        stdout_content = """a key
+> different value
+
+a array
+> [1, 3, "4 (new)", "5 (new)"]
+
+a aoh
+> [{"id": 0, "name": "zero", "extra_field": "is an extra field (new)"}, {"id": 1, "name": "different one"}, {"id": "3 (new)", "name": "three (new)"}, {"id": "4 (new)", "name": "four (new)"}]
+
+a rhs_exclusive
+> {"with": {"structure": true}}
+"""
+
+        result = subprocess.run(
+            [self.command
+            , "-"
+            , rhs_file
+            ]
+            , stdout=subprocess.PIPE
+            , input=""
+            , universal_newlines=True
+        )
+        assert 1 == result.returncode, result.stderr
+        assert stdout_content == result.stdout
+
+    def test_simple_diff_array_from_nothing_via_stdin(self, script_runner, tmp_path_factory):
+        import subprocess
+        rhs_file = create_temp_yaml_file(tmp_path_factory, self.rhs_array_content)
+        stdout_content = """a [0]
+> {"step": 1, "action": "input", "args": ["le monde"]}
+
+a [1]
+> {"step": 2, "action": "print", "message": "A tout %args[0]!"}
+"""
+
+        result = subprocess.run(
+            [self.command
+            , "-"
+            , rhs_file
+            ]
+            , stdout=subprocess.PIPE
+            , input=""
+            , universal_newlines=True
+        )
+        assert 1 == result.returncode, result.stderr
+        assert stdout_content == result.stdout
+
+    def test_simple_diff_hash_from_text_via_stdin(self, script_runner, tmp_path_factory):
+        import subprocess
+        rhs_file = create_temp_yaml_file(tmp_path_factory, self.rhs_hash_content)
+        stdout_content = """d -
+< This is a general text file.
+
+a key
+> different value
+
+a array
+> [1, 3, "4 (new)", "5 (new)"]
+
+a aoh
+> [{"id": 0, "name": "zero", "extra_field": "is an extra field (new)"}, {"id": 1, "name": "different one"}, {"id": "3 (new)", "name": "three (new)"}, {"id": "4 (new)", "name": "four (new)"}]
+
+a rhs_exclusive
+> {"with": {"structure": true}}
+"""
+
+        result = subprocess.run(
+            [self.command
+            , "-"
+            , rhs_file
+            ]
+            , stdout=subprocess.PIPE
+            , input="This is a general text file."
+            , universal_newlines=True
+        )
+        assert 1 == result.returncode, result.stderr
+        assert stdout_content == result.stdout
+
+    def test_simple_diff_array_from_text_via_stdin(self, script_runner, tmp_path_factory):
+        import subprocess
+        rhs_file = create_temp_yaml_file(tmp_path_factory, self.rhs_array_content)
+        stdout_content = """d -
+< This is a general text file.
+
+a [0]
+> {"step": 1, "action": "input", "args": ["le monde"]}
+
+a [1]
+> {"step": 2, "action": "print", "message": "A tout %args[0]!"}
+"""
+
+        result = subprocess.run(
+            [self.command
+            , "-"
+            , rhs_file
+            ]
+            , stdout=subprocess.PIPE
+            , input="This is a general text file."
+            , universal_newlines=True
+        )
+        assert 1 == result.returncode, result.stderr
+        assert stdout_content == result.stdout
+
+    def test_simple_diff_hash_into_nothing_via_stdin(self, script_runner, tmp_path_factory):
+        import subprocess
+        lhs_file = create_temp_yaml_file(tmp_path_factory, self.lhs_hash_content)
+        stdout_content = """d key
+< value
+
+d array
+< [1, 2, 3]
+
+d aoh
+< [{"id": 0, "name": "zero"}, {"id": 1, "name": "one"}, {"id": 2, "name": "two"}]
+
+d lhs_exclusive
+< ["node"]
+"""
+
+        result = subprocess.run(
+            [self.command
+            , lhs_file
+            , "-"
+            ]
+            , stdout=subprocess.PIPE
+            , input=""
+            , universal_newlines=True
+        )
+        assert 1 == result.returncode, result.stderr
+        assert stdout_content == result.stdout
+
+    def test_simple_diff_array_into_nothing_via_stdin(self, script_runner, tmp_path_factory):
+        import subprocess
+        lhs_file = create_temp_yaml_file(tmp_path_factory, self.lhs_array_content)
+        stdout_content = """d [0]
+< {"step": 1, "action": "input", "args": ["world"]}
+
+d [1]
+< {"step": 2, "action": "print", "message": "Hello, %args[0]!"}
+
+d [2]
+< {"step": 3, "action": "quit", "status": 0}
+"""
+
+        result = subprocess.run(
+            [self.command
+            , lhs_file
+            , "-"
+            ]
+            , stdout=subprocess.PIPE
+            , input=""
+            , universal_newlines=True
+        )
+        assert 1 == result.returncode, result.stderr
+        assert stdout_content == result.stdout
+
+    def test_simple_diff_hash_into_text_via_stdin(self, script_runner, tmp_path_factory):
+        import subprocess
+        lhs_file = create_temp_yaml_file(tmp_path_factory, self.lhs_hash_content)
+        stdout_content = """a -
+> This is a general text file.
+
+d key
+< value
+
+d array
+< [1, 2, 3]
+
+d aoh
+< [{"id": 0, "name": "zero"}, {"id": 1, "name": "one"}, {"id": 2, "name": "two"}]
+
+d lhs_exclusive
+< ["node"]
+"""
+
+        result = subprocess.run(
+            [self.command
+            , lhs_file
+            , "-"
+            ]
+            , stdout=subprocess.PIPE
+            , input="This is a general text file."
+            , universal_newlines=True
+        )
+        assert 1 == result.returncode, result.stderr
+        assert stdout_content == result.stdout
+
+    def test_simple_diff_array_into_text_via_stdin(self, script_runner, tmp_path_factory):
+        import subprocess
+        lhs_file = create_temp_yaml_file(tmp_path_factory, self.lhs_array_content)
+        stdout_content = """a -
+> This is a general text file.
+
+d [0]
+< {"step": 1, "action": "input", "args": ["world"]}
+
+d [1]
+< {"step": 2, "action": "print", "message": "Hello, %args[0]!"}
+
+d [2]
+< {"step": 3, "action": "quit", "status": 0}
+"""
+
+        result = subprocess.run(
+            [self.command
+            , lhs_file
+            , "-"
+            ]
+            , stdout=subprocess.PIPE
+            , input="This is a general text file."
+            , universal_newlines=True
+        )
+        assert 1 == result.returncode, result.stderr
+        assert stdout_content == result.stdout
+
+    def test_onlysame_diff_two_hash_files(self, script_runner, tmp_path_factory):
+        lhs_file = create_temp_yaml_file(tmp_path_factory, self.lhs_hash_content)
+        rhs_file = create_temp_yaml_file(tmp_path_factory, self.rhs_hash_content)
+        stdout_content = """s array[0]
+= 1
+
+s aoh[0].id
+= 0
+
+s aoh[0].name
+= zero
+
+s aoh[1].id
+= 1
+"""
+
+        # DEBUG
+        # print("LHS File:  {}".format(lhs_file))
+        # print("RHS File:  {}".format(rhs_file))
+        # print("Expected Output:")
+        # print(merged_yaml_content)
+
+        result = script_runner.run(
+            self.command
+            , "--onlysame"
+            , lhs_file
+            , rhs_file)
+        assert not result.success, result.stderr
+        assert stdout_content == result.stdout
+
+    def test_onlysame_diff_two_array_files(self, script_runner, tmp_path_factory):
+        lhs_file = create_temp_yaml_file(tmp_path_factory, self.lhs_array_content)
+        rhs_file = create_temp_yaml_file(tmp_path_factory, self.rhs_array_content)
+        stdout_content = """s [0].step
+= 1
+
+s [0].action
+= input
+
+s [1].step
+= 2
+
+s [1].action
+= print
+"""
+
+        # DEBUG
+        # print("LHS File:  {}".format(lhs_file))
+        # print("RHS File:  {}".format(rhs_file))
+        # print("Expected Output:")
+        # print(merged_yaml_content)
+
+        result = script_runner.run(
+            self.command
+            , "--onlysame"
+            , lhs_file
+            , rhs_file)
+        assert not result.success, result.stderr
+        assert stdout_content == result.stdout
+
+    def test_diff_two_aliased_hash_files(self, script_runner, tmp_path_factory):
+        """
+        Test Anchors, their Aliases, and YAML Merge Operators.
+
+        Also demonstrate that the yaml-diff tool is a FUNCTIONAL comparison of
+        two data files, NOT a textual comparison.  In other words, yaml-diff is
+        only interested in how the data is represented to YAML/JSON parsers,
+        NOT how the YAML/JSON file is constructed.  Immaterial elements like
+        comments, white-space, and demarcation symbols are deliberately ignored
+        because none of these have any impact on what data YAML/JSON parsers
+        actually percieve to be within the files at run-time.
+
+        Users who need a TEXTUAL (non-functional) comparison of two YAML/JSON
+        files should use the GNU `diff` command-line tool rather than this
+        yaml-diff command-line tool.
+        """
+        lhs_file = create_temp_yaml_file(tmp_path_factory, """---
+aliases:
+  - &string_value This is a reusable string value.
+  - &int_value 5280
+some_values: &some_values
+  aliased_int: *int_value
+  original_float: 3.14159265358
+more_values: &more_values
+  aliased_string: *string_value
+  original_string: This is another reusable string except its in a reusable parent Hash.
+collector_hash:
+  <<: [ *some_values, *more_values ]
+  concrete_string: This is a non-reusable concrete string.
+""")
+        rhs_file = create_temp_yaml_file(tmp_path_factory, """---
+# Reusable aliases
+aliases:
+  - &string_value This is a CHANGED reusable string value.
+  - &aliased_int_value 5280
+
+# Reusable numbers reusing one number
+some_values: &some_values
+  aliased_int: *aliased_int_value
+  original_float: 3.14
+
+# Reusable strings reusing one string
+more_values: &more_values
+  aliased_string: *string_value
+  original_string: "This is another reusable string except its in a reusable parent Hash."
+
+# Bring it all together
+collector_hash:
+  <<: [ *some_values, *more_values ]
+  concrete_string: 'This is a non-reusable concrete string.'
+""")
+        stdout_content = """c aliases[0]
+< This is a reusable string value.
+---
+> This is a CHANGED reusable string value.
+
+c some_values.original_float
+< 3.14159265358
+---
+> 3.14
+
+c more_values.aliased_string
+< This is a reusable string value.
+---
+> This is a CHANGED reusable string value.
+
+c collector_hash.original_float
+< 3.14159265358
+---
+> 3.14
+
+c collector_hash.aliased_string
+< This is a reusable string value.
+---
+> This is a CHANGED reusable string value.
+"""
+
+        # DEBUG
+        # print("LHS File:  {}".format(lhs_file))
+        # print("RHS File:  {}".format(rhs_file))
+        # print("Expected Output:")
+        # print(merged_yaml_content)
+
+        result = script_runner.run(
+            self.command
+            , lhs_file
+            , rhs_file)
+        assert not result.success, result.stderr
+        assert stdout_content == result.stdout
+
+    def test_simple_diff_two_hash_files_fslash(self, script_runner, tmp_path_factory):
+        lhs_file = create_temp_yaml_file(tmp_path_factory, self.lhs_hash_content)
+        rhs_file = create_temp_yaml_file(tmp_path_factory, self.rhs_hash_content)
+        stdout_content = """c /key
+< value
+---
+> different value
+
+c /array[1]
+< 2
+---
+> 3
+
+c /array[2]
+< 3
+---
+> 4 (new)
+
+a /array[3]
+> 5 (new)
+
+a /aoh[0]/extra_field
+> is an extra field (new)
+
+c /aoh[1]/name
+< one
+---
+> different one
+
+c /aoh[2]/id
+< 2
+---
+> 3 (new)
+
+c /aoh[2]/name
+< two
+---
+> three (new)
+
+d /lhs_exclusive
+< ["node"]
+
+a /aoh[3]
+> {"id": "4 (new)", "name": "four (new)"}
+
+a /rhs_exclusive
+> {"with": {"structure": true}}
+"""
+
+        # DEBUG
+        # print("LHS File:  {}".format(lhs_file))
+        # print("RHS File:  {}".format(rhs_file))
+        # print("Expected Output:")
+        # print(merged_yaml_content)
+
+        result = script_runner.run(
+            self.command
+            , "--pathsep=/"
+            , lhs_file
+            , rhs_file)
+        assert not result.success, result.stderr
+        assert stdout_content == result.stdout
+
+    @requireseyaml
+    def test_diff_eyaml_allowed(self, script_runner, tmp_path_factory, old_eyaml_keys):
+        lhs_file = create_temp_yaml_file(tmp_path_factory, """---
+same_secret_same_crypt: >
+  ENC[PKCS7,MIIBygYJKoZIhvcNAQcDoIIBuzCCAbcCAQAxggEhMIIBHQIBADAFMAACAQEw
+  DQYJKoZIhvcNAQEBBQAEggEAP5tXc8gPp1p5945Ih/i/k/OqvoDrWi/F05/V
+  EhlgUwXgNer0Y5C7G/FE4Gt5nasoolbPQTMVuq+CW8qQ6wsnVrB60SCDvy5q
+  9k7WGHyQU5n6UR00/RLhctStGe6nN/zIsoYLQyyY/+xJaHAwahB/GkzFPk9S
+  F2Zu+fsxj1X38XVuGFC+Nx89ODXnNYBxRuElUK9qHuC5rCRyPBWEM9brv6Am
+  7+PCig9WZSxXUkDyX6hG2Mzm/ndKgqonhCEBOp3CrDrmFdWCdmx81Qe1dLRl
+  mSonHjWYyFugtrRz6YV7Ni1cicEZoKUFT/XXqntX1BS97M9Ms8AZODrDxB66
+  rpZ41jCBjAYJKoZIhvcNAQcBMB0GCWCGSAFlAwQBKgQQBHXHyWGQNDL6l7tA
+  9Rf784BgLbcaRZMscSjL/ym69YQXRJPzo3nCBSVOCUrVtU0pGFpkSUvdYRmr
+  ZVlZ5jcv9xiU+ktGJZhjzzVcSHYMf9LkwtCiHYRYzVgDX/S24/NSVF5NEeTz
+  MvIW862oA8UFtodj]
+same_secret_different_crypt: >
+  ENC[PKCS7,MIIBygYJKoZIhvcNAQcDoIIBuzCCAbcCAQAxggEhMIIBHQIBADAFMAACAQEw
+  DQYJKoZIhvcNAQEBBQAEggEAYUDg4y4+LXY0IdEDYFgxfxRJ3dfkOPwTSLxl
+  A91x5IQlgQYQpXkgkFEeJj3EXdYwt9K6prtFywokVQoOaWgXWWV+Tf0lF5P0
+  0sw4LH7MgaszKPpiOHxx9hTmexEIusF+tzvQBOD1zHfDdkZQ0v9R3JLHckub
+  rg/XOLJXzkkyKEoKIFScBT115aedGY60baMtvD1Md9rxi97xCmj6BroatMlM
+  Cm266oFnijrQN9Xsb5ZTnGiPMA9hC2y6X+oJeMaG0S6G64EnTwnjAQytWE6a
+  JM1/YXVKIoE2c/E44/m74kuyO70RwACV9QknSqoLuUbYpcbU4FHU/xICiWAG
+  CaTz9zCBjAYJKoZIhvcNAQcBMB0GCWCGSAFlAwQBKgQQ9kFVNmG9heK0WyWU
+  R1kfyIBgCIJzi+XnQMS9w85Mbq6BaNPpJrU7ZaoHQ6c3Ps9sgJStVDQNmrbL
+  WAP8fEC6S7V07rA7hp4YomvAJRJjDIK7M2AzXDNzupuAh4crF905AR4TF+Jd
+  nNuWarGVGx1Bv+6h]
+different_secrets: >
+  ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEw
+  DQYJKoZIhvcNAQEBBQAEggEAJRw+urxm+Pyt0Xys5UpJUIaZhA0Tt1JuVsLG
+  9jiHb9aua+2bBr/kAN8D/+dowOJlVkG6LZ4Uzn+NZboO8Q2JpQeV9CJTqayJ
+  eZnRx02298qSrWOogSQUoS/or0+QWGLeQqJMiNuUx6IHskyWVsROamTmK9p2
+  gAgL5bAXzD2+1MHIRMrf8ascVmTOV4/JMckWznCseM+uJ7PkR12044mWhuvk
+  aJUjaXFXIEYhA4+jjKWdlOTWJAFkjhKE6HAHqaNZVlcf8X1WuoX4f1iPP53z
+  mATu0eDx8D5XwQnygUMrPWrlCyoIqRIcwU6f5iv+HT1EWEvSI5+i7bByx0hk
+  apUR+TBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCgVC5h5pznSfACl7+Q
+  ff+mgDBAZPMofXWfguD6OgcXu0/QMz90QHAN4bu+CHHZLZ+8X3qSgKHszijK
+  eEeStAMoq50=]
+""")
+        rhs_file = create_temp_yaml_file(tmp_path_factory, """---
+same_secret_same_crypt: >
+  ENC[PKCS7,MIIBygYJKoZIhvcNAQcDoIIBuzCCAbcCAQAxggEhMIIBHQIBADAFMAACAQEw
+  DQYJKoZIhvcNAQEBBQAEggEAP5tXc8gPp1p5945Ih/i/k/OqvoDrWi/F05/V
+  EhlgUwXgNer0Y5C7G/FE4Gt5nasoolbPQTMVuq+CW8qQ6wsnVrB60SCDvy5q
+  9k7WGHyQU5n6UR00/RLhctStGe6nN/zIsoYLQyyY/+xJaHAwahB/GkzFPk9S
+  F2Zu+fsxj1X38XVuGFC+Nx89ODXnNYBxRuElUK9qHuC5rCRyPBWEM9brv6Am
+  7+PCig9WZSxXUkDyX6hG2Mzm/ndKgqonhCEBOp3CrDrmFdWCdmx81Qe1dLRl
+  mSonHjWYyFugtrRz6YV7Ni1cicEZoKUFT/XXqntX1BS97M9Ms8AZODrDxB66
+  rpZ41jCBjAYJKoZIhvcNAQcBMB0GCWCGSAFlAwQBKgQQBHXHyWGQNDL6l7tA
+  9Rf784BgLbcaRZMscSjL/ym69YQXRJPzo3nCBSVOCUrVtU0pGFpkSUvdYRmr
+  ZVlZ5jcv9xiU+ktGJZhjzzVcSHYMf9LkwtCiHYRYzVgDX/S24/NSVF5NEeTz
+  MvIW862oA8UFtodj]
+same_secret_different_crypt: >
+  ENC[PKCS7,MIIBygYJKoZIhvcNAQcDoIIBuzCCAbcCAQAxggEhMIIBHQIBADAFMAACAQEw
+  DQYJKoZIhvcNAQEBBQAEggEAV/S/jxC79aiKR1UnPxcrPo7bLpSpsoUqJfdQ
+  znMp0LJrqacIcrq+jFRLqFUv2dDcTRnReP5CZy4HEJw73710Ngb+sJLQeCE9
+  f8qYvjKAlWyrw0Strpwe5BQT4g7ph5GX3lOqjCBJbqRPE9XfhI9DPljkUzBB
+  IQ8zVZz/zy5TbBCRZm7RKPjbczTMaHRRQb0fEKnK7tTdHIucNRQh0AZ9ZGuJ
+  8TchxlBhgtwjKU0NxbpQyi/hVyv7Dw8/wSq3Wp5nFYJj1uFxYES0sw6QAsM+
+  1LzY2hg+RCzL3gxU724gH0xRCv346tKoyqzVxtO+knLVh/m8HulrXJABKn0/
+  ZJrBezCBjAYJKoZIhvcNAQcBMB0GCWCGSAFlAwQBKgQQMvmLomzj48fPsA1H
+  DVQiaoBgctgTfmmKEaEoCYJqd4WXpJeb96viMyTXRaa8Pt0rl22mbt92qMUk
+  witfhD7lzteg1k2tunXQx8w37vx60kqY3aEXV8crQb1TQdBUuZIks1RnLFur
+  14/eAgRAn37NhJli]
+different_secrets: >
+  ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEw
+  DQYJKoZIhvcNAQEBBQAEggEAm9Sw3jUCLMOKU0wpQgu7kW4yO/MvoLbQpWMB
+  KKFEssxhJ0Kqc5Q+2cTAk6vo5K7GopVYr5iCaaoxLmCJq3ke1XBR6O182q/2
+  vcvgqTVq3OaaMR3qji1edJQd6NJuqpuV+tIf6RCktt5+9wlIXLxujnaYxmr1
+  vrEMXnb0R6PWunXsTAlDDrCVMC6iXIvbhsP2GF8zhhuTkCXp1LTDuvj3aSso
+  iloELuCdCGO7iFTXPuPy4nrgXjlaVnGftoDmVukDP8PUzyEBT1a9ZXUjrswS
+  sXzCsTnEGIpPlIe84Nvk43osbVw2sOgwod7Uko7KmdXVFAh8l15BoW5E9uRw
+  y2XahTBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBAIA2FJ1Fo38jwnbHs8
+  V8GOgDAaCmR9jyjK/0f0V2WnRF+nPS21sNoB0qONn1V0GwAQbu0yk7QS5y8q
+  4OTZEGxziGU=]
+""")
+        stdout_content = """c different_secrets
+< ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAJRw+urxm+Pyt0Xys5UpJUIaZhA0Tt1JuVsLG9jiHb9aua+2bBr/kAN8D/+dowOJlVkG6LZ4Uzn+NZboO8Q2JpQeV9CJTqayJeZnRx02298qSrWOogSQUoS/or0+QWGLeQqJMiNuUx6IHskyWVsROamTmK9p2gAgL5bAXzD2+1MHIRMrf8ascVmTOV4/JMckWznCseM+uJ7PkR12044mWhuvkaJUjaXFXIEYhA4+jjKWdlOTWJAFkjhKE6HAHqaNZVlcf8X1WuoX4f1iPP53zmATu0eDx8D5XwQnygUMrPWrlCyoIqRIcwU6f5iv+HT1EWEvSI5+i7bByx0hkapUR+TBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCgVC5h5pznSfACl7+Qff+mgDBAZPMofXWfguD6OgcXu0/QMz90QHAN4bu+CHHZLZ+8X3qSgKHszijKeEeStAMoq50=]
+---
+> ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAm9Sw3jUCLMOKU0wpQgu7kW4yO/MvoLbQpWMBKKFEssxhJ0Kqc5Q+2cTAk6vo5K7GopVYr5iCaaoxLmCJq3ke1XBR6O182q/2vcvgqTVq3OaaMR3qji1edJQd6NJuqpuV+tIf6RCktt5+9wlIXLxujnaYxmr1vrEMXnb0R6PWunXsTAlDDrCVMC6iXIvbhsP2GF8zhhuTkCXp1LTDuvj3aSsoiloELuCdCGO7iFTXPuPy4nrgXjlaVnGftoDmVukDP8PUzyEBT1a9ZXUjrswSsXzCsTnEGIpPlIe84Nvk43osbVw2sOgwod7Uko7KmdXVFAh8l15BoW5E9uRwy2XahTBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBAIA2FJ1Fo38jwnbHs8V8GOgDAaCmR9jyjK/0f0V2WnRF+nPS21sNoB0qONn1V0GwAQbu0yk7QS5y8q4OTZEGxziGU=]
+"""
+
+        # DEBUG
+        # print("LHS File:  {}".format(lhs_file))
+        # print("RHS File:  {}".format(rhs_file))
+        # print("Expected Output:")
+        # print(merged_yaml_content)
+
+        result = script_runner.run(
+            self.command
+            , "--privatekey={}".format(old_eyaml_keys[0])
+            , "--publickey={}".format(old_eyaml_keys[1])
+            , lhs_file
+            , rhs_file)
+        assert not result.success, result.stderr
+        assert stdout_content == result.stdout
+
+    def test_diff_eyaml_disallowed(self, script_runner, tmp_path_factory, old_eyaml_keys):
+        lhs_file = create_temp_yaml_file(tmp_path_factory, """---
+same_secret_same_crypt: >
+  ENC[PKCS7,MIIBygYJKoZIhvcNAQcDoIIBuzCCAbcCAQAxggEhMIIBHQIBADAFMAACAQEw
+  DQYJKoZIhvcNAQEBBQAEggEAP5tXc8gPp1p5945Ih/i/k/OqvoDrWi/F05/V
+  EhlgUwXgNer0Y5C7G/FE4Gt5nasoolbPQTMVuq+CW8qQ6wsnVrB60SCDvy5q
+  9k7WGHyQU5n6UR00/RLhctStGe6nN/zIsoYLQyyY/+xJaHAwahB/GkzFPk9S
+  F2Zu+fsxj1X38XVuGFC+Nx89ODXnNYBxRuElUK9qHuC5rCRyPBWEM9brv6Am
+  7+PCig9WZSxXUkDyX6hG2Mzm/ndKgqonhCEBOp3CrDrmFdWCdmx81Qe1dLRl
+  mSonHjWYyFugtrRz6YV7Ni1cicEZoKUFT/XXqntX1BS97M9Ms8AZODrDxB66
+  rpZ41jCBjAYJKoZIhvcNAQcBMB0GCWCGSAFlAwQBKgQQBHXHyWGQNDL6l7tA
+  9Rf784BgLbcaRZMscSjL/ym69YQXRJPzo3nCBSVOCUrVtU0pGFpkSUvdYRmr
+  ZVlZ5jcv9xiU+ktGJZhjzzVcSHYMf9LkwtCiHYRYzVgDX/S24/NSVF5NEeTz
+  MvIW862oA8UFtodj]
+same_secret_different_crypt: >
+  ENC[PKCS7,MIIBygYJKoZIhvcNAQcDoIIBuzCCAbcCAQAxggEhMIIBHQIBADAFMAACAQEw
+  DQYJKoZIhvcNAQEBBQAEggEAYUDg4y4+LXY0IdEDYFgxfxRJ3dfkOPwTSLxl
+  A91x5IQlgQYQpXkgkFEeJj3EXdYwt9K6prtFywokVQoOaWgXWWV+Tf0lF5P0
+  0sw4LH7MgaszKPpiOHxx9hTmexEIusF+tzvQBOD1zHfDdkZQ0v9R3JLHckub
+  rg/XOLJXzkkyKEoKIFScBT115aedGY60baMtvD1Md9rxi97xCmj6BroatMlM
+  Cm266oFnijrQN9Xsb5ZTnGiPMA9hC2y6X+oJeMaG0S6G64EnTwnjAQytWE6a
+  JM1/YXVKIoE2c/E44/m74kuyO70RwACV9QknSqoLuUbYpcbU4FHU/xICiWAG
+  CaTz9zCBjAYJKoZIhvcNAQcBMB0GCWCGSAFlAwQBKgQQ9kFVNmG9heK0WyWU
+  R1kfyIBgCIJzi+XnQMS9w85Mbq6BaNPpJrU7ZaoHQ6c3Ps9sgJStVDQNmrbL
+  WAP8fEC6S7V07rA7hp4YomvAJRJjDIK7M2AzXDNzupuAh4crF905AR4TF+Jd
+  nNuWarGVGx1Bv+6h]
+different_secrets: >
+  ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEw
+  DQYJKoZIhvcNAQEBBQAEggEAJRw+urxm+Pyt0Xys5UpJUIaZhA0Tt1JuVsLG
+  9jiHb9aua+2bBr/kAN8D/+dowOJlVkG6LZ4Uzn+NZboO8Q2JpQeV9CJTqayJ
+  eZnRx02298qSrWOogSQUoS/or0+QWGLeQqJMiNuUx6IHskyWVsROamTmK9p2
+  gAgL5bAXzD2+1MHIRMrf8ascVmTOV4/JMckWznCseM+uJ7PkR12044mWhuvk
+  aJUjaXFXIEYhA4+jjKWdlOTWJAFkjhKE6HAHqaNZVlcf8X1WuoX4f1iPP53z
+  mATu0eDx8D5XwQnygUMrPWrlCyoIqRIcwU6f5iv+HT1EWEvSI5+i7bByx0hk
+  apUR+TBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCgVC5h5pznSfACl7+Q
+  ff+mgDBAZPMofXWfguD6OgcXu0/QMz90QHAN4bu+CHHZLZ+8X3qSgKHszijK
+  eEeStAMoq50=]
+""")
+        rhs_file = create_temp_yaml_file(tmp_path_factory, """---
+same_secret_same_crypt: >
+  ENC[PKCS7,MIIBygYJKoZIhvcNAQcDoIIBuzCCAbcCAQAxggEhMIIBHQIBADAFMAACAQEw
+  DQYJKoZIhvcNAQEBBQAEggEAP5tXc8gPp1p5945Ih/i/k/OqvoDrWi/F05/V
+  EhlgUwXgNer0Y5C7G/FE4Gt5nasoolbPQTMVuq+CW8qQ6wsnVrB60SCDvy5q
+  9k7WGHyQU5n6UR00/RLhctStGe6nN/zIsoYLQyyY/+xJaHAwahB/GkzFPk9S
+  F2Zu+fsxj1X38XVuGFC+Nx89ODXnNYBxRuElUK9qHuC5rCRyPBWEM9brv6Am
+  7+PCig9WZSxXUkDyX6hG2Mzm/ndKgqonhCEBOp3CrDrmFdWCdmx81Qe1dLRl
+  mSonHjWYyFugtrRz6YV7Ni1cicEZoKUFT/XXqntX1BS97M9Ms8AZODrDxB66
+  rpZ41jCBjAYJKoZIhvcNAQcBMB0GCWCGSAFlAwQBKgQQBHXHyWGQNDL6l7tA
+  9Rf784BgLbcaRZMscSjL/ym69YQXRJPzo3nCBSVOCUrVtU0pGFpkSUvdYRmr
+  ZVlZ5jcv9xiU+ktGJZhjzzVcSHYMf9LkwtCiHYRYzVgDX/S24/NSVF5NEeTz
+  MvIW862oA8UFtodj]
+same_secret_different_crypt: >
+  ENC[PKCS7,MIIBygYJKoZIhvcNAQcDoIIBuzCCAbcCAQAxggEhMIIBHQIBADAFMAACAQEw
+  DQYJKoZIhvcNAQEBBQAEggEAV/S/jxC79aiKR1UnPxcrPo7bLpSpsoUqJfdQ
+  znMp0LJrqacIcrq+jFRLqFUv2dDcTRnReP5CZy4HEJw73710Ngb+sJLQeCE9
+  f8qYvjKAlWyrw0Strpwe5BQT4g7ph5GX3lOqjCBJbqRPE9XfhI9DPljkUzBB
+  IQ8zVZz/zy5TbBCRZm7RKPjbczTMaHRRQb0fEKnK7tTdHIucNRQh0AZ9ZGuJ
+  8TchxlBhgtwjKU0NxbpQyi/hVyv7Dw8/wSq3Wp5nFYJj1uFxYES0sw6QAsM+
+  1LzY2hg+RCzL3gxU724gH0xRCv346tKoyqzVxtO+knLVh/m8HulrXJABKn0/
+  ZJrBezCBjAYJKoZIhvcNAQcBMB0GCWCGSAFlAwQBKgQQMvmLomzj48fPsA1H
+  DVQiaoBgctgTfmmKEaEoCYJqd4WXpJeb96viMyTXRaa8Pt0rl22mbt92qMUk
+  witfhD7lzteg1k2tunXQx8w37vx60kqY3aEXV8crQb1TQdBUuZIks1RnLFur
+  14/eAgRAn37NhJli]
+different_secrets: >
+  ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEw
+  DQYJKoZIhvcNAQEBBQAEggEAm9Sw3jUCLMOKU0wpQgu7kW4yO/MvoLbQpWMB
+  KKFEssxhJ0Kqc5Q+2cTAk6vo5K7GopVYr5iCaaoxLmCJq3ke1XBR6O182q/2
+  vcvgqTVq3OaaMR3qji1edJQd6NJuqpuV+tIf6RCktt5+9wlIXLxujnaYxmr1
+  vrEMXnb0R6PWunXsTAlDDrCVMC6iXIvbhsP2GF8zhhuTkCXp1LTDuvj3aSso
+  iloELuCdCGO7iFTXPuPy4nrgXjlaVnGftoDmVukDP8PUzyEBT1a9ZXUjrswS
+  sXzCsTnEGIpPlIe84Nvk43osbVw2sOgwod7Uko7KmdXVFAh8l15BoW5E9uRw
+  y2XahTBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBAIA2FJ1Fo38jwnbHs8
+  V8GOgDAaCmR9jyjK/0f0V2WnRF+nPS21sNoB0qONn1V0GwAQbu0yk7QS5y8q
+  4OTZEGxziGU=]
+""")
+        stdout_content = """c same_secret_different_crypt
+< ENC[PKCS7,MIIBygYJKoZIhvcNAQcDoIIBuzCCAbcCAQAxggEhMIIBHQIBADAFMAACAQEw DQYJKoZIhvcNAQEBBQAEggEAYUDg4y4+LXY0IdEDYFgxfxRJ3dfkOPwTSLxl A91x5IQlgQYQpXkgkFEeJj3EXdYwt9K6prtFywokVQoOaWgXWWV+Tf0lF5P0 0sw4LH7MgaszKPpiOHxx9hTmexEIusF+tzvQBOD1zHfDdkZQ0v9R3JLHckub rg/XOLJXzkkyKEoKIFScBT115aedGY60baMtvD1Md9rxi97xCmj6BroatMlM Cm266oFnijrQN9Xsb5ZTnGiPMA9hC2y6X+oJeMaG0S6G64EnTwnjAQytWE6a JM1/YXVKIoE2c/E44/m74kuyO70RwACV9QknSqoLuUbYpcbU4FHU/xICiWAG CaTz9zCBjAYJKoZIhvcNAQcBMB0GCWCGSAFlAwQBKgQQ9kFVNmG9heK0WyWU R1kfyIBgCIJzi+XnQMS9w85Mbq6BaNPpJrU7ZaoHQ6c3Ps9sgJStVDQNmrbL WAP8fEC6S7V07rA7hp4YomvAJRJjDIK7M2AzXDNzupuAh4crF905AR4TF+Jd nNuWarGVGx1Bv+6h]
+---
+> ENC[PKCS7,MIIBygYJKoZIhvcNAQcDoIIBuzCCAbcCAQAxggEhMIIBHQIBADAFMAACAQEw DQYJKoZIhvcNAQEBBQAEggEAV/S/jxC79aiKR1UnPxcrPo7bLpSpsoUqJfdQ znMp0LJrqacIcrq+jFRLqFUv2dDcTRnReP5CZy4HEJw73710Ngb+sJLQeCE9 f8qYvjKAlWyrw0Strpwe5BQT4g7ph5GX3lOqjCBJbqRPE9XfhI9DPljkUzBB IQ8zVZz/zy5TbBCRZm7RKPjbczTMaHRRQb0fEKnK7tTdHIucNRQh0AZ9ZGuJ 8TchxlBhgtwjKU0NxbpQyi/hVyv7Dw8/wSq3Wp5nFYJj1uFxYES0sw6QAsM+ 1LzY2hg+RCzL3gxU724gH0xRCv346tKoyqzVxtO+knLVh/m8HulrXJABKn0/ ZJrBezCBjAYJKoZIhvcNAQcBMB0GCWCGSAFlAwQBKgQQMvmLomzj48fPsA1H DVQiaoBgctgTfmmKEaEoCYJqd4WXpJeb96viMyTXRaa8Pt0rl22mbt92qMUk witfhD7lzteg1k2tunXQx8w37vx60kqY3aEXV8crQb1TQdBUuZIks1RnLFur 14/eAgRAn37NhJli]
+
+c different_secrets
+< ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEw DQYJKoZIhvcNAQEBBQAEggEAJRw+urxm+Pyt0Xys5UpJUIaZhA0Tt1JuVsLG 9jiHb9aua+2bBr/kAN8D/+dowOJlVkG6LZ4Uzn+NZboO8Q2JpQeV9CJTqayJ eZnRx02298qSrWOogSQUoS/or0+QWGLeQqJMiNuUx6IHskyWVsROamTmK9p2 gAgL5bAXzD2+1MHIRMrf8ascVmTOV4/JMckWznCseM+uJ7PkR12044mWhuvk aJUjaXFXIEYhA4+jjKWdlOTWJAFkjhKE6HAHqaNZVlcf8X1WuoX4f1iPP53z mATu0eDx8D5XwQnygUMrPWrlCyoIqRIcwU6f5iv+HT1EWEvSI5+i7bByx0hk apUR+TBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCgVC5h5pznSfACl7+Q ff+mgDBAZPMofXWfguD6OgcXu0/QMz90QHAN4bu+CHHZLZ+8X3qSgKHszijK eEeStAMoq50=]
+---
+> ENC[PKCS7,MIIBmQYJKoZIhvcNAQcDoIIBijCCAYYCAQAxggEhMIIBHQIBADAFMAACAQEw DQYJKoZIhvcNAQEBBQAEggEAm9Sw3jUCLMOKU0wpQgu7kW4yO/MvoLbQpWMB KKFEssxhJ0Kqc5Q+2cTAk6vo5K7GopVYr5iCaaoxLmCJq3ke1XBR6O182q/2 vcvgqTVq3OaaMR3qji1edJQd6NJuqpuV+tIf6RCktt5+9wlIXLxujnaYxmr1 vrEMXnb0R6PWunXsTAlDDrCVMC6iXIvbhsP2GF8zhhuTkCXp1LTDuvj3aSso iloELuCdCGO7iFTXPuPy4nrgXjlaVnGftoDmVukDP8PUzyEBT1a9ZXUjrswS sXzCsTnEGIpPlIe84Nvk43osbVw2sOgwod7Uko7KmdXVFAh8l15BoW5E9uRw y2XahTBcBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBAIA2FJ1Fo38jwnbHs8 V8GOgDAaCmR9jyjK/0f0V2WnRF+nPS21sNoB0qONn1V0GwAQbu0yk7QS5y8q 4OTZEGxziGU=]
+"""
+
+        # DEBUG
+        # print("LHS File:  {}".format(lhs_file))
+        # print("RHS File:  {}".format(rhs_file))
+        # print("Expected Output:")
+        # print(merged_yaml_content)
+
+        result = script_runner.run(
+            self.command
+            , "--ignore-eyaml-values"
+            , lhs_file
+            , rhs_file)
+        assert not result.success, result.stderr
+        assert stdout_content == result.stdout
+
+    def test_diff_two_multiline_string_hash_files(self, script_runner, tmp_path_factory):
+        lhs_file = create_temp_yaml_file(tmp_path_factory, """---
+folded_string: >
+  This is
+  one really long
+  string.  It
+  is presented in
+  YAML "folded"
+  format.  This will
+  cause all of the
+  new-line characters
+  to be replaced with
+  single spaces
+  when this value
+  is read by a
+  YAML parser.
+
+literal_string: |
+  This is another
+  really long string.
+  It is presented in
+  YAML "literal"
+  format.  When a
+  YAML parser reads
+  this value, all of
+  these new-line
+  characters will be
+  preserved.
+""")
+        rhs_file = create_temp_yaml_file(tmp_path_factory, """---
+folded_string: >
+  This CHANGED
+  one really long
+  string.  It
+  is presented in
+  YAML "folded"
+  format.  This will
+  cause all of the
+  new-line characters
+  to be replaced with
+  single spaces
+  when this value
+  is read by a
+  YAML parser.
+
+literal_string: |
+  This is another
+  really long CHANGED string.
+  It is presented in
+  YAML "literal"
+  format.  When a
+  YAML parser reads
+  this value, all of
+  these new-line
+  characters will be
+  preserved.
+""")
+        stdout_content = """c folded_string
+< This is one really long string.  It is presented in YAML "folded" format.  This will cause all of the new-line characters to be replaced with single spaces when this value is read by a YAML parser.
+---
+> This CHANGED one really long string.  It is presented in YAML "folded" format.  This will cause all of the new-line characters to be replaced with single spaces when this value is read by a YAML parser.
+
+c literal_string
+< This is another
+< really long string.
+< It is presented in
+< YAML "literal"
+< format.  When a
+< YAML parser reads
+< this value, all of
+< these new-line
+< characters will be
+< preserved.
+---
+> This is another
+> really long CHANGED string.
+> It is presented in
+> YAML "literal"
+> format.  When a
+> YAML parser reads
+> this value, all of
+> these new-line
+> characters will be
+> preserved.
+"""
+
+        # DEBUG
+        # print("LHS File:  {}".format(lhs_file))
+        # print("RHS File:  {}".format(rhs_file))
+        # print("Expected Output:")
+        # print(merged_yaml_content)
+
+        result = script_runner.run(
+            self.command
+            , lhs_file
+            , rhs_file)
+        assert not result.success, result.stderr
+        assert stdout_content == result.stdout
+
+    def test_diff_two_multiline_string_hash_files_verbosely(self, script_runner, tmp_path_factory):
+        lhs_file = create_temp_yaml_file(tmp_path_factory, """---
+folded_string: >
+  This is
+  one really long
+  string.  It
+  is presented in
+  YAML "folded"
+  format.  This will
+  cause all of the
+  new-line characters
+  to be replaced with
+  single spaces
+  when this value
+  is read by a
+  YAML parser.
+
+literal_string: |
+  This is another
+  really long string.
+  It is presented in
+  YAML "literal"
+  format.  When a
+  YAML parser reads
+  this value, all of
+  these new-line
+  characters will be
+  preserved.
+""")
+        rhs_file = create_temp_yaml_file(tmp_path_factory, """---
+folded_string: >
+  This CHANGED
+  one really long
+  string.  It
+  is presented in
+  YAML "folded"
+  format.  This will
+  cause all of the
+  new-line characters
+  to be replaced with
+  single spaces
+  when this value
+  is read by a
+  YAML parser.
+
+literal_string: |
+  This is another
+  really long CHANGED string.
+  It is presented in
+  YAML "literal"
+  format.  When a
+  YAML parser reads
+  this value, all of
+  these new-line
+  characters will be
+  preserved.
+""")
+        stdout_content = """c1.0.1.0 folded_string
+< This is one really long string.  It is presented in YAML "folded" format.  This will cause all of the new-line characters to be replaced with single spaces when this value is read by a YAML parser.
+---
+> This CHANGED one really long string.  It is presented in YAML "folded" format.  This will cause all of the new-line characters to be replaced with single spaces when this value is read by a YAML parser.
+
+c1.0.1.0 literal_string
+< This is another
+< really long string.
+< It is presented in
+< YAML "literal"
+< format.  When a
+< YAML parser reads
+< this value, all of
+< these new-line
+< characters will be
+< preserved.
+---
+> This is another
+> really long CHANGED string.
+> It is presented in
+> YAML "literal"
+> format.  When a
+> YAML parser reads
+> this value, all of
+> these new-line
+> characters will be
+> preserved.
+"""
+
+        # DEBUG
+        # print("LHS File:  {}".format(lhs_file))
+        # print("RHS File:  {}".format(rhs_file))
+        # print("Expected Output:")
+        # print(merged_yaml_content)
+
+        result = script_runner.run(
+            self.command
+            , "--verbose"
+            , lhs_file
+            , rhs_file)
+        assert not result.success, result.stderr
+        assert stdout_content == result.stdout
+
+    def test_sync_arrays(self, script_runner, tmp_path_factory):
+        lhs_file = create_temp_yaml_file(tmp_path_factory, """---
+- alpha
+- mu
+- psi
+- beta
+- delta
+- chi
+- delta
+- gamma
+- alpha
+""")
+        rhs_file = create_temp_yaml_file(tmp_path_factory, """---
+- zeta
+- mu
+- psi
+- alpha
+- gamma
+- gamma
+- phi
+- beta
+- chi
+""")
+        stdout_content = """d [4]
+< delta
+
+d [6]
+< delta
+
+d [8]
+< alpha
+
+a [9]
+> zeta
+
+a [10]
+> gamma
+
+a [11]
+> phi
+"""
+
+        # DEBUG
+        # print("LHS File:  {}".format(lhs_file))
+        # print("RHS File:  {}".format(rhs_file))
+        # print("Expected Output:")
+        # print(merged_yaml_content)
+
+        result = script_runner.run(
+            self.command
+            , "--sync-arrays"
+            , lhs_file
+            , rhs_file)
+        assert not result.success, result.stderr
+        assert stdout_content == result.stdout

--- a/tests/test_commands_yaml_diff.py
+++ b/tests/test_commands_yaml_diff.py
@@ -150,6 +150,11 @@ d [2]
         assert not result.success, result.stderr
         assert "File not found" in result.stderr
 
+    def test_cannot_quiet_sameness(self, script_runner):
+        result = script_runner.run(self.command, "--quiet", "--same", "any-file.yaml", "any-other-file.json")
+        assert not result.success, result.stderr
+        assert "The --quiet|-q option suppresses all output, including" in result.stderr
+
     def test_bad_eyaml_value(self, script_runner, tmp_path_factory):
         content = """---
         aliases:
@@ -286,6 +291,24 @@ d [2]
             , universal_newlines=True
         )
         assert 0 == result.returncode, result.stderr
+        assert "" == result.stdout
+
+    def test_quiet_diff_two_hash_files(self, script_runner, tmp_path_factory):
+        lhs_file = create_temp_yaml_file(tmp_path_factory, self.lhs_hash_content)
+        rhs_file = create_temp_yaml_file(tmp_path_factory, self.rhs_hash_content)
+
+        # DEBUG
+        # print("LHS File:  {}".format(lhs_file))
+        # print("RHS File:  {}".format(rhs_file))
+        # print("Expected Output:")
+        # print(merged_yaml_content)
+
+        result = script_runner.run(
+            self.command
+            , "--quiet"
+            , lhs_file
+            , rhs_file)
+        assert not result.success, result.stderr
         assert "" == result.stdout
 
     def test_simple_diff_two_hash_files(self, script_runner, tmp_path_factory):

--- a/tests/test_differ_differconfig.py
+++ b/tests/test_differ_differconfig.py
@@ -1,0 +1,366 @@
+import pytest
+from types import SimpleNamespace
+
+from yamlpath.func import get_yaml_editor, get_yaml_data
+from yamlpath.differ.enums import (
+    AoHDiffOpts,
+    ArrayDiffOpts,
+)
+from yamlpath.wrappers import NodeCoords
+from yamlpath.differ import DifferConfig
+from yamlpath import YAMLPath
+from tests.conftest import (
+    info_warn_logger,
+    quiet_logger,
+    create_temp_yaml_file
+)
+
+class Test_differ_DifferConfig():
+    """Tests for the DifferConfig class."""
+
+    ###
+    # array_diff_mode
+    ###
+    def test_array_diff_mode_default(self, quiet_logger):
+        mc = DifferConfig(quiet_logger, SimpleNamespace(arrays=None))
+        assert mc.array_diff_mode(
+            NodeCoords(None, None, None)) == ArrayDiffOpts.POSITION
+
+    @pytest.mark.parametrize("setting, mode", [
+        ("position", ArrayDiffOpts.POSITION),
+        ("value", ArrayDiffOpts.VALUE),
+    ])
+    def test_array_diff_mode_cli(self, quiet_logger, setting, mode):
+        mc = DifferConfig(quiet_logger, SimpleNamespace(arrays=setting))
+        assert mc.array_diff_mode(
+            NodeCoords(None, None, None)) == mode
+
+    @pytest.mark.parametrize("setting, mode", [
+        ("position", ArrayDiffOpts.POSITION),
+        ("value", ArrayDiffOpts.VALUE),
+    ])
+    def test_array_diff_mode_ini(
+        self, quiet_logger, tmp_path_factory, setting, mode
+    ):
+        config_file = create_temp_yaml_file(tmp_path_factory, """
+        [defaults]
+        arrays = {}
+        """.format(setting))
+        mc = DifferConfig(quiet_logger, SimpleNamespace(
+            config=config_file
+            , arrays=None))
+        assert mc.array_diff_mode(
+            NodeCoords(None, None, None)) == mode
+
+    @pytest.mark.parametrize("cli, ini, mode", [
+        ("position", "value", ArrayDiffOpts.POSITION),
+        ("value", "position", ArrayDiffOpts.VALUE),
+    ])
+    def test_array_diff_mode_cli_overrides_ini_defaults(
+        self, quiet_logger, tmp_path_factory, cli, ini, mode
+    ):
+        config_file = create_temp_yaml_file(tmp_path_factory, """
+        [defaults]
+        arrays = {}
+        """.format(ini))
+        mc = DifferConfig(quiet_logger, SimpleNamespace(
+            config=config_file
+            , arrays=cli))
+        assert mc.array_diff_mode(
+            NodeCoords(None, None, None)) == mode
+
+    @pytest.mark.parametrize("cli, ini_default, ini_rule, mode", [
+        ("value", "value", "position", ArrayDiffOpts.POSITION),
+        ("position", "position", "value", ArrayDiffOpts.VALUE),
+    ])
+    def test_array_diff_mode_ini_rule_overrides_cli(
+        self, quiet_logger, tmp_path_factory, cli, ini_default, ini_rule, mode
+    ):
+        config_file = create_temp_yaml_file(tmp_path_factory, """
+        [defaults]
+        arrays = {}
+        [rules]
+        /hash/diff_targets/subarray = {}
+        """.format(ini_default, ini_rule))
+        lhs_yaml_file = create_temp_yaml_file(tmp_path_factory, """---
+        hash:
+          lhs_exclusive: lhs value 1
+          diff_targets:
+            subkey: lhs value 2
+            subarray:
+              - one
+              - two
+        array_of_hashes:
+          - name: LHS Record 1
+            id: 1
+            prop: LHS value AoH 1
+          - name: LHS Record 2
+            id: 2
+            prop: LHS value AoH 2
+        """)
+        lhs_yaml = get_yaml_editor()
+        (lhs_data, lhs_loaded) = get_yaml_data(lhs_yaml, quiet_logger, lhs_yaml_file)
+
+        mc = DifferConfig(quiet_logger, SimpleNamespace(
+            config=config_file
+            , arrays=cli))
+        mc.prepare(lhs_data)
+
+        node = lhs_data["hash"]["diff_targets"]["subarray"]
+        parent = lhs_data["hash"]["diff_targets"]
+        parentref = "subarray"
+
+        assert mc.array_diff_mode(
+            NodeCoords(node, parent, parentref)) == mode
+
+
+    ###
+    # aoh_diff_mode
+    ###
+    def test_aoh_diff_mode_default(self, quiet_logger):
+        mc = DifferConfig(quiet_logger, SimpleNamespace(aoh=None))
+        assert mc.aoh_diff_mode(
+            NodeCoords(None, None, None)) == AoHDiffOpts.POSITION
+
+    @pytest.mark.parametrize("setting, mode", [
+        ("deep", AoHDiffOpts.DEEP),
+        ("dpos", AoHDiffOpts.DPOS),
+        ("key", AoHDiffOpts.KEY),
+        ("position", AoHDiffOpts.POSITION),
+        ("value", AoHDiffOpts.VALUE),
+    ])
+    def test_aoh_diff_mode_cli(self, quiet_logger, setting, mode):
+        mc = DifferConfig(quiet_logger, SimpleNamespace(aoh=setting))
+        assert mc.aoh_diff_mode(
+            NodeCoords(None, None, None)) == mode
+
+    @pytest.mark.parametrize("setting, mode", [
+        ("deep", AoHDiffOpts.DEEP),
+        ("dpos", AoHDiffOpts.DPOS),
+        ("key", AoHDiffOpts.KEY),
+        ("position", AoHDiffOpts.POSITION),
+        ("value", AoHDiffOpts.VALUE),
+    ])
+    def test_aoh_diff_mode_ini(
+        self, quiet_logger, tmp_path_factory, setting, mode
+    ):
+        config_file = create_temp_yaml_file(tmp_path_factory, """
+        [defaults]
+        aoh = {}
+        """.format(setting))
+        mc = DifferConfig(quiet_logger, SimpleNamespace(
+            config=config_file
+            , aoh=None))
+        assert mc.aoh_diff_mode(
+            NodeCoords(None, None, None)) == mode
+
+    @pytest.mark.parametrize("cli, ini, mode", [
+        ("deep", "dpos", AoHDiffOpts.DEEP),
+        ("dpos", "key", AoHDiffOpts.DPOS),
+        ("key", "position", AoHDiffOpts.KEY),
+        ("position", "value", AoHDiffOpts.POSITION),
+        ("value", "deep", AoHDiffOpts.VALUE),
+    ])
+    def test_aoh_diff_mode_cli_overrides_ini_defaults(
+        self, quiet_logger, tmp_path_factory, cli, ini, mode
+    ):
+        config_file = create_temp_yaml_file(tmp_path_factory, """
+        [defaults]
+        aoh = {}
+        """.format(ini))
+        mc = DifferConfig(quiet_logger, SimpleNamespace(
+            config=config_file
+            , aoh=cli))
+        assert mc.aoh_diff_mode(
+            NodeCoords(None, None, None)) == mode
+
+    @pytest.mark.parametrize("cli, ini_default, ini_rule, mode", [
+        ("deep", "dpos", "key", AoHDiffOpts.KEY),
+        ("dpos", "key", "position", AoHDiffOpts.POSITION),
+        ("key", "position", "value", AoHDiffOpts.VALUE),
+        ("position", "value", "deep", AoHDiffOpts.DEEP),
+        ("value", "deep", "dpos", AoHDiffOpts.DPOS),
+    ])
+    def test_aoh_diff_mode_ini_rule_overrides_cli(
+        self, quiet_logger, tmp_path_factory, cli, ini_default, ini_rule, mode
+    ):
+        config_file = create_temp_yaml_file(tmp_path_factory, """
+        [defaults]
+        aoh = {}
+        [rules]
+        /array_of_hashes = {}
+        """.format(ini_default, ini_rule))
+        lhs_yaml_file = create_temp_yaml_file(tmp_path_factory, """---
+        hash:
+          lhs_exclusive: lhs value 1
+          diff_targets:
+            subkey: lhs value 2
+            subarray:
+              - one
+              - two
+        array_of_hashes:
+          - name: LHS Record 1
+            id: 1
+            prop: LHS value AoH 1
+          - name: LHS Record 2
+            id: 2
+            prop: LHS value AoH 2
+        """)
+        lhs_yaml = get_yaml_editor()
+        (lhs_data, lhs_loaded) = get_yaml_data(lhs_yaml, quiet_logger, lhs_yaml_file)
+
+        mc = DifferConfig(quiet_logger, SimpleNamespace(
+            config=config_file
+            , aoh=cli))
+        mc.prepare(lhs_data)
+
+        node = lhs_data["array_of_hashes"]
+        parent = lhs_data
+        parentref = "array_of_hashes"
+
+        assert mc.aoh_diff_mode(
+            NodeCoords(node, parent, parentref)) == mode
+
+
+    ###
+    # aoh_diff_key
+    ###
+    def test_aoh_diff_key_default(self, quiet_logger, tmp_path_factory):
+        lhs_yaml_file = create_temp_yaml_file(tmp_path_factory, """---
+        hash:
+          lhs_exclusive: lhs value 1
+          diff_targets:
+            subkey: lhs value 2
+            subarray:
+              - one
+              - two
+        array_of_hashes:
+          - name: LHS Record 1
+            id: 1
+            prop: LHS value AoH 1
+          - name: LHS Record 2
+            id: 2
+            prop: LHS value AoH 2
+        """)
+        lhs_yaml = get_yaml_editor()
+        (lhs_data, lhs_loaded) = get_yaml_data(lhs_yaml, quiet_logger, lhs_yaml_file)
+
+        mc = DifferConfig(quiet_logger, SimpleNamespace())
+        mc.prepare(lhs_data)
+
+        node = lhs_data["array_of_hashes"]
+        parent = lhs_data
+        parentref = "array_of_hashes"
+        record = node[0]
+
+        assert mc.aoh_diff_key(
+            NodeCoords(node, parent, parentref), record) == "name"
+
+    def test_aoh_diff_key_ini(self, quiet_logger, tmp_path_factory):
+        config_file = create_temp_yaml_file(tmp_path_factory, """
+        [keys]
+        /array_of_hashes = id
+        """)
+        lhs_yaml_file = create_temp_yaml_file(tmp_path_factory, """---
+        hash:
+          lhs_exclusive: lhs value 1
+          diff_targets:
+            subkey: lhs value 2
+            subarray:
+              - one
+              - two
+        array_of_hashes:
+          - name: LHS Record 1
+            id: 1
+            prop: LHS value AoH 1
+          - name: LHS Record 2
+            id: 2
+            prop: LHS value AoH 2
+        """)
+        lhs_yaml = get_yaml_editor()
+        (lhs_data, lhs_loaded) = get_yaml_data(lhs_yaml, quiet_logger, lhs_yaml_file)
+
+        mc = DifferConfig(quiet_logger, SimpleNamespace(config=config_file))
+        mc.prepare(lhs_data)
+
+        node = lhs_data["array_of_hashes"]
+        parent = lhs_data
+        parentref = "array_of_hashes"
+        record = node[0]
+
+        assert mc.aoh_diff_key(
+            NodeCoords(node, parent, parentref), record) == "id"
+
+    def test_aoh_diff_key_ini_inferred_parent(
+        self, quiet_logger, tmp_path_factory
+    ):
+        config_file = create_temp_yaml_file(tmp_path_factory, """
+        [keys]
+        /array_of_hashes = prop
+        """)
+        lhs_yaml_file = create_temp_yaml_file(tmp_path_factory, """---
+        hash:
+          lhs_exclusive: lhs value 1
+          diff_targets:
+            subkey: lhs value 2
+            subarray:
+              - one
+              - two
+        array_of_hashes:
+          - name: LHS Record 1
+            id: 1
+            prop: LHS value AoH 1
+          - name: LHS Record 2
+            id: 2
+            prop: LHS value AoH 2
+        """)
+        lhs_yaml = get_yaml_editor()
+        (lhs_data, lhs_loaded) = get_yaml_data(lhs_yaml, quiet_logger, lhs_yaml_file)
+
+        mc = DifferConfig(quiet_logger, SimpleNamespace(config=config_file))
+        mc.prepare(lhs_data)
+
+        node = lhs_data["array_of_hashes"][1]
+        parent = lhs_data["array_of_hashes"]
+        parentref = 1
+        record = node
+
+        assert mc.aoh_diff_key(
+            NodeCoords(node, parent, parentref), record) == "prop"
+
+
+    ###
+    # Edge Cases
+    ###
+    def test_warn_when_rules_matches_zero_nodes(
+        self, capsys, info_warn_logger, tmp_path_factory
+    ):
+        config_file = create_temp_yaml_file(tmp_path_factory, """
+        [rules]
+        /does_not_exist = left
+        /array_of_hashes[name = "Does Not Compute"] = right
+        """)
+        lhs_yaml_file = create_temp_yaml_file(tmp_path_factory, """---
+        hash:
+          lhs_exclusive: lhs value 1
+          diff_targets:
+            subkey: lhs value 2
+            subarray:
+              - one
+              - two
+        array_of_hashes:
+          - name: LHS Record 1
+            id: 1
+            prop: LHS value AoH 1
+          - name: LHS Record 2
+            id: 2
+            prop: LHS value AoH 2
+        """)
+        lhs_yaml = get_yaml_editor()
+        lhs_data = get_yaml_data(lhs_yaml, info_warn_logger, lhs_yaml_file)
+
+        mc = DifferConfig(info_warn_logger, SimpleNamespace(config=config_file))
+        mc.prepare(lhs_data)
+
+        console = capsys.readouterr()
+        assert "YAML Path matches no nodes" in console.out

--- a/tests/test_differ_enums_aohdiffopts.py
+++ b/tests/test_differ_enums_aohdiffopts.py
@@ -1,0 +1,39 @@
+import pytest
+
+from yamlpath.differ.enums.aohdiffopts import AoHDiffOpts
+
+
+class Test_differ_enums_aohdiffopts():
+	"""Tests for the AoHDiffOpts enumeration."""
+
+	def test_get_names(self):
+		assert AoHDiffOpts.get_names() == [
+			"DEEP",
+			"DPOS",
+			"KEY",
+			"POSITION",
+			"VALUE",
+		]
+
+	def test_get_choices(self):
+		assert AoHDiffOpts.get_choices() == [
+			"deep",
+			"dpos",
+			"key",
+			"position",
+			"value",
+		]
+
+	@pytest.mark.parametrize("input,output", [
+		("DEEP", AoHDiffOpts.DEEP),
+		("DPOS", AoHDiffOpts.DPOS),
+		("KEY", AoHDiffOpts.KEY),
+		("POSITION", AoHDiffOpts.POSITION),
+		("VALUE", AoHDiffOpts.VALUE),
+	])
+	def test_from_str(self, input, output):
+		assert output == AoHDiffOpts.from_str(input)
+
+	def test_from_str_nameerror(self):
+		with pytest.raises(NameError):
+			AoHDiffOpts.from_str("NO SUCH NAME")

--- a/tests/test_differ_enums_arraydiffopts.py
+++ b/tests/test_differ_enums_arraydiffopts.py
@@ -1,0 +1,30 @@
+import pytest
+
+from yamlpath.differ.enums.arraydiffopts import ArrayDiffOpts
+
+
+class Test_differ_enums_arraydiffopts():
+	"""Tests for the ArrayDiffOpts enumeration."""
+
+	def test_get_names(self):
+		assert ArrayDiffOpts.get_names() == [
+			"POSITION",
+			"VALUE",
+		]
+
+	def test_get_choices(self):
+		assert ArrayDiffOpts.get_choices() == [
+			"position",
+			"value",
+		]
+
+	@pytest.mark.parametrize("input,output", [
+		("POSITION", ArrayDiffOpts.POSITION),
+		("VALUE", ArrayDiffOpts.VALUE),
+	])
+	def test_from_str(self, input, output):
+		assert output == ArrayDiffOpts.from_str(input)
+
+	def test_from_str_nameerror(self):
+		with pytest.raises(NameError):
+			ArrayDiffOpts.from_str("NO SUCH NAME")

--- a/tests/test_wrappers_consoleprinter.py
+++ b/tests/test_wrappers_consoleprinter.py
@@ -7,6 +7,7 @@ from ruamel.yaml.scalarstring import PlainScalarString
 
 from yamlpath.wrappers import NodeCoords
 from yamlpath.wrappers import ConsolePrinter
+from yamlpath import YAMLPath
 
 class Test_wrappers_ConsolePrinter():
     def test_info_noisy(self, capsys):
@@ -129,12 +130,13 @@ class Test_wrappers_ConsolePrinter():
             "DEBUG:  test_debug_noisy:  === FOOTER ===",
         ]) + "\n" == console.out
 
-        nc = NodeCoords("value", dict(key="value"), "key")
+        nc = NodeCoords("value", dict(key="value"), "key", YAMLPath("key"))
         logger.debug(
             "A node coordinate:", prefix="test_debug_noisy:  ", data=nc)
         console = capsys.readouterr()
         assert "\n".join([
             "DEBUG:  test_debug_noisy:  A node coordinate:",
+            "DEBUG:  test_debug_noisy:  (path)key",
             "DEBUG:  test_debug_noisy:  (node)value",
             "DEBUG:  test_debug_noisy:  (parent)[key]value<class 'str'>",
             "DEBUG:  test_debug_noisy:  (parentref)key",

--- a/yamlpath/__init__.py
+++ b/yamlpath/__init__.py
@@ -1,3 +1,6 @@
 """Core YAML Path classes."""
+# Establish the version number common to all components
+__version__ = "3.3.0"
+
 from yamlpath.yamlpath import YAMLPath
 from yamlpath.processor import Processor

--- a/yamlpath/commands/eyaml_rotate_keys.py
+++ b/yamlpath/commands/eyaml_rotate_keys.py
@@ -14,7 +14,7 @@ from os.path import isfile, exists
 
 from ruamel.yaml.scalarstring import FoldedScalarString
 
-from yamlpath.common import YAMLPATH_VERSION
+from yamlpath import __version__ as YAMLPATH_VERSION
 from yamlpath.func import get_yaml_data, get_yaml_editor
 from yamlpath.eyaml.exceptions import EYAMLCommandException
 from yamlpath.eyaml import EYAMLProcessor

--- a/yamlpath/commands/eyaml_rotate_keys.py
+++ b/yamlpath/commands/eyaml_rotate_keys.py
@@ -26,11 +26,17 @@ from yamlpath.wrappers import ConsolePrinter
 def processcli():
     """Process command-line arguments."""
     parser = argparse.ArgumentParser(
-        description="Rotates the encryption keys used for all EYAML values"
-        + " within a set of YAML files, decrypting with old keys and"
-        + " re-encrypting using replacement keys.",
-        epilog="Any YAML_FILEs lacking EYAML values will not be modified (or"
-        + " backed up, even when -b/--backup is specified)."
+        description=(
+            "Rotates the encryption keys used for all EYAML values"
+            " within a set of YAML files, decrypting with old keys and"
+            " re-encrypting using replacement keys."),
+        epilog=(
+            "Any YAML_FILEs lacking EYAML values will not be modified (or"
+            " backed up, even when -b/--backup is specified).  For more"
+            " information about YAML Paths, please visit"
+            " https://github.com/wwkimball/yamlpath/wiki.  To report issues"
+            " with this tool or to request enhancements, please visit"
+            " https://github.com/wwkimball/yamlpath/issues.")
     )
     parser.add_argument("-V", "--version", action="version",
                         version="%(prog)s " + YAMLPATH_VERSION)

--- a/yamlpath/commands/yaml_diff.py
+++ b/yamlpath/commands/yaml_diff.py
@@ -23,19 +23,20 @@ def processcli():
         formatter_class=argparse.RawTextHelpFormatter,
         description=(
             "Compare YAML/JSON/Compatible documents node by node.  EYAML can"
-            "be employed to\ncompare encrypted values."),
+            " be employed to\ncompare encrypted values."),
         epilog="""
 configuration file:
   The CONFIG file is an INI file with up to three sections:
   [defaults] Sets equivalents of --arrays|-A and --aoh|-O.
   [rules]    Each entry is a YAML Path assigning --arrays|-A or --aoh|-O for
              precise nodes.
-  [keys]     Wherever --aoh=bykey (or -O bykey), each entry is treated as a
-             record with an identity key.  In order to match RHS records to
-             LHS records, a key must be known and is identified on a YAML
-             Path basis via this section.  Where not specified, the first
-             attribute of the first record in the Array-of-Hashes is presumed
-             the identity key for all records in the set.
+  [keys]     Wherever --aoh=key (or -O key) or --aoh=deep (or -O deep), each
+             entry is treated as a record with an identity key.  In order to
+             match RHS records to LHS records, a key must be known and is
+             identified on a YAML Path basis via this section.  Where not
+             specified, the first attribute of the first record in the
+             Array-of-Hashes is presumed the identity key for all records in
+             the set.
 
 input files:
   Only one input file may be the - pseudo-file (read from STDIN).  Because the

--- a/yamlpath/commands/yaml_diff.py
+++ b/yamlpath/commands/yaml_diff.py
@@ -1,0 +1,170 @@
+"""
+Calculate the differences between two YAML/JSON/Compatible documents.
+
+Copyright 2020 William W. Kimball, Jr. MBA MSIS
+"""
+import sys
+import argparse
+
+from yamlpath.common import YAMLPATH_VERSION
+from yamlpath.enums import PathSeperators
+from yamlpath.wrappers import ConsolePrinter
+from yamlpath.func import get_yaml_data, get_yaml_editor
+from yamlpath.differ import Differ
+from yamlpath.differ.enums import DiffActions
+from yamlpath.eyaml.exceptions.eyamlcommand import EYAMLCommandException
+
+def processcli():
+    """Process command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Calculate the functional difference between two"
+                    " YAML/JSON/Compatible documents.  Immaterial differences"
+                    " (which YAML/JSON parsers discard) are ignored.  EYAML"
+                    " can be employed to compare encrypted values.",
+        epilog="Only one YAML_FILE may be the - pseudo-file for reading from"
+               " STDIN.  For more information about YAML Paths, please visit"
+               " https://github.com/wwkimball/yamlpath."
+    )
+    parser.add_argument("-V", "--version", action="version",
+                        version="%(prog)s " + YAMLPATH_VERSION)
+
+    parser.add_argument(
+        "-a", "--sync-arrays",
+        action="store_true",
+        help="Synchronize array elements before comparing them, resulting only"
+             " in ADD, DELETE, and SAME differences (no CHANGEs because the"
+             " positions of elements are disregarded); Array-of-Hash elements"
+             " must completely and perfectly match or they will be deemed"
+             " additions or deletions")
+
+    sameness_group = parser.add_mutually_exclusive_group()
+    sameness_group.add_argument(
+        "-s", "--same", action="store_true",
+        help="Show all nodes which are the same in addition to differences")
+    sameness_group.add_argument(
+        "-o", "--onlysame", action="store_true",
+        help="Show only nodes which are the same, still reporting that"
+             " differences exist -- when they do -- with an exit-state of 1")
+
+    parser.add_argument(
+        "-t", "--pathsep",
+        default="dot",
+        choices=PathSeperators,
+        metavar=PathSeperators.get_choices(),
+        type=PathSeperators.from_str,
+        help="indicate which YAML Path seperator to use when rendering"
+             " results; default=dot")
+
+    eyaml_group = parser.add_argument_group(
+        "EYAML options", "Left unset, the EYAML keys will default to your\
+         system or user defaults.  Both keys must be set either here or in\
+         your system or user EYAML configuration file when using EYAML.")
+    eyaml_group.add_argument(
+        "-x", "--eyaml",
+        default="eyaml",
+        help="the eyaml binary to use when it isn't on the PATH")
+    eyaml_group.add_argument("-r", "--privatekey", help="EYAML private key")
+    eyaml_group.add_argument("-u", "--publickey", help="EYAML public key")
+    eyaml_group.add_argument(
+        "-E", "--ignore-eyaml-values",
+        action="store_true",
+        help="Do not use EYAML to compare encrypted data; rather, treat"
+             " ENC[...] values as regular strings")
+
+    noise_group = parser.add_mutually_exclusive_group()
+    noise_group.add_argument(
+        "-d", "--debug",
+        action="store_true",
+        help="output debugging details")
+    noise_group.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        help="increase output verbosity")
+    noise_group.add_argument(
+        "-q", "--quiet",
+        action="store_true",
+        help="suppress all output except system errors")
+
+    parser.add_argument("yaml_files", metavar="YAML_FILE",
+                        nargs=2,
+                        help="exactly two YAML/JSON/compatible files to"
+                             " compare; use - to read one document from STDIN")
+
+    return parser.parse_args()
+
+def validateargs(args, log):
+    """Validate command-line arguments."""
+    has_errors = False
+
+    # There can be only one -
+    pseudofile_count = 0
+    for infile in args.yaml_files:
+        if infile.strip() == '-':
+            pseudofile_count += 1
+    if pseudofile_count > 1:
+        has_errors = True
+        log.error("Only one YAML_FILE may be the - pseudo-file.")
+
+    if has_errors:
+        sys.exit(1)
+
+def print_report(log, args, diff):
+    """Print user-customized report."""
+    changes_found = False
+    print_sep = False
+    print_verbosely = args.verbose or args.debug
+    for entry in diff.get_report():
+        is_different = entry.action is not DiffActions.SAME
+        if is_different:
+            changes_found = True
+
+        if (
+            (is_different and not args.onlysame)
+            or (args.onlysame and not is_different)
+            or args.same
+        ):
+            if print_sep:
+                log.info("")
+            entry.pathsep = args.pathsep
+            entry.verbose = print_verbosely
+            log.info(entry)
+            print_sep = True
+
+    return changes_found
+
+def main():
+    """Main code."""
+    args = processcli()
+    log = ConsolePrinter(args)
+    validateargs(args, log)
+    exit_state = 0
+    lhs_file = args.yaml_files[0]
+    rhs_file = args.yaml_files[1] if len(args.yaml_files) > 1 else "-"
+    lhs_yaml = get_yaml_editor()
+    rhs_yaml = get_yaml_editor()
+
+    (lhs_document, doc_loaded) = get_yaml_data(lhs_yaml, log, lhs_file)
+    if not doc_loaded:
+        # An error message has already been logged
+        sys.exit(1)
+
+    (rhs_document, doc_loaded) = get_yaml_data(rhs_yaml, log, rhs_file)
+    if not doc_loaded:
+        # An error message has already been logged
+        sys.exit(1)
+
+    diff = Differ(
+        log, lhs_document, sync_arrays=args.sync_arrays,
+        ignore_eyaml_values=args.ignore_eyaml_values, binary=args.eyaml,
+        publickey=args.publickey, privatekey=args.privatekey)
+
+    try:
+        diff.compare_to(rhs_document)
+    except EYAMLCommandException as ex:
+        log.critical(ex, 1)
+
+    exit_state = 1 if print_report(log, args, diff) else 0
+    sys.exit(exit_state)
+
+if __name__ == "__main__":
+    main()  # pragma: no cover

--- a/yamlpath/commands/yaml_diff.py
+++ b/yamlpath/commands/yaml_diff.py
@@ -8,7 +8,7 @@ import argparse
 from os import access, R_OK
 from os.path import isfile
 
-from yamlpath.common import YAMLPATH_VERSION
+from yamlpath import __version__ as YAMLPATH_VERSION
 from yamlpath.enums import PathSeperators
 from yamlpath.differ.enums import AoHDiffOpts, ArrayDiffOpts
 from yamlpath.wrappers import ConsolePrinter

--- a/yamlpath/commands/yaml_diff.py
+++ b/yamlpath/commands/yaml_diff.py
@@ -105,6 +105,13 @@ def validateargs(args, log):
         has_errors = True
         log.error("Only one YAML_FILE may be the - pseudo-file.")
 
+    # --quiet cannot be used with --same or --onlysame
+    if args.quiet and (args.same or args.onlysame):
+        has_errors = True
+        log.error(
+            "The --quiet|-q option suppresses all output, including that of"
+            " --same|-s and --onlysame|-o, so they cannot be set together.")
+
     if has_errors:
         sys.exit(1)
 
@@ -117,6 +124,9 @@ def print_report(log, args, diff):
         is_different = entry.action is not DiffActions.SAME
         if is_different:
             changes_found = True
+
+        if args.quiet:
+            continue
 
         if (
             (is_different and not args.onlysame)

--- a/yamlpath/commands/yaml_diff.py
+++ b/yamlpath/commands/yaml_diff.py
@@ -5,46 +5,84 @@ Copyright 2020 William W. Kimball, Jr. MBA MSIS
 """
 import sys
 import argparse
+from os import access, R_OK
+from os.path import isfile
 
 from yamlpath.common import YAMLPATH_VERSION
 from yamlpath.enums import PathSeperators
+from yamlpath.differ.enums import AoHDiffOpts, ArrayDiffOpts
 from yamlpath.wrappers import ConsolePrinter
 from yamlpath.func import get_yaml_data, get_yaml_editor
-from yamlpath.differ import Differ
+from yamlpath.differ import DifferConfig, Differ
 from yamlpath.differ.enums import DiffActions
 from yamlpath.eyaml.exceptions.eyamlcommand import EYAMLCommandException
 
 def processcli():
     """Process command-line arguments."""
     parser = argparse.ArgumentParser(
-        description="Calculate the functional difference between two"
-                    " YAML/JSON/Compatible documents.  Immaterial differences"
-                    " (which YAML/JSON parsers discard) are ignored.  EYAML"
-                    " can be employed to compare encrypted values.",
-        epilog="Only one YAML_FILE may be the - pseudo-file for reading from"
-               " STDIN.  For more information about YAML Paths, please visit"
-               " https://github.com/wwkimball/yamlpath."
-    )
+        formatter_class=argparse.RawTextHelpFormatter,
+        description=(
+            "Compare YAML/JSON/Compatible documents node by node.  EYAML can"
+            "be employed to\ncompare encrypted values."),
+        epilog="""
+configuration file:
+  The CONFIG file is an INI file with up to three sections:
+  [defaults] Sets equivalents of --arrays|-A and --aoh|-O.
+  [rules]    Each entry is a YAML Path assigning --arrays|-A or --aoh|-O for
+             precise nodes.
+  [keys]     Wherever --aoh=bykey (or -O bykey), each entry is treated as a
+             record with an identity key.  In order to match RHS records to
+             LHS records, a key must be known and is identified on a YAML
+             Path basis via this section.  Where not specified, the first
+             attribute of the first record in the Array-of-Hashes is presumed
+             the identity key for all records in the set.
+
+input files:
+  Only one input file may be the - pseudo-file (read from STDIN).  Because the
+  relative position of the two input files is important, this will not be
+  inferred; you must use - to indicate which document is read from STDIN.
+
+  It doesn't make any sense to compare multi-document files, so only single-
+  document files are supported.
+
+For more information about YAML Paths, please visit
+https://github.com/wwkimball/yamlpath/wiki.
+
+To report issues with this tool or to request enhancements, please visit
+https://github.com/wwkimball/yamlpath/issues.
+""")
     parser.add_argument("-V", "--version", action="version",
                         version="%(prog)s " + YAMLPATH_VERSION)
 
     parser.add_argument(
-        "-a", "--sync-arrays",
-        action="store_true",
-        help="Synchronize array elements before comparing them, resulting only"
-             " in ADD, DELETE, and SAME differences (no CHANGEs because the"
-             " positions of elements are disregarded); Array-of-Hash elements"
-             " must completely and perfectly match or they will be deemed"
-             " additions or deletions")
+        "-c", "--config",
+        help="INI syle configuration file for YAML Path specified\ncomparison"
+             " control options")
+
+    parser.add_argument(
+        "-A", "--arrays",
+        choices=[l.lower() for l in ArrayDiffOpts.get_names()],
+        type=str.lower,
+        help="default means by which Arrays are compared (overrides\n"
+            "[defaults]arrays but is overridden on a YAML Path\nbasis via"
+            " --config|-c); default={}".format(ArrayDiffOpts.POSITION))
+    parser.add_argument(
+        "-O", "--aoh",
+        choices=[l.lower() for l in AoHDiffOpts.get_names()],
+        type=str.lower,
+        help=(
+            "default means by which Arrays-of-Hashes are compared\n(overrides"
+            " [defaults]aoh but is overridden on a YAML\nPath basis in [rules]"
+            " set via --config|-c);\ndefault={}".format(AoHDiffOpts.POSITION)))
 
     sameness_group = parser.add_mutually_exclusive_group()
     sameness_group.add_argument(
         "-s", "--same", action="store_true",
-        help="Show all nodes which are the same in addition to differences")
+        help="Show all nodes which are the same in addition to\ndifferences")
     sameness_group.add_argument(
         "-o", "--onlysame", action="store_true",
-        help="Show only nodes which are the same, still reporting that"
-             " differences exist -- when they do -- with an exit-state of 1")
+        help="Show only nodes which are the same, still reporting\nthat"
+             " differences exist -- when they do -- with an\nexit-state of 1")
 
     parser.add_argument(
         "-t", "--pathsep",
@@ -52,13 +90,13 @@ def processcli():
         choices=PathSeperators,
         metavar=PathSeperators.get_choices(),
         type=PathSeperators.from_str,
-        help="indicate which YAML Path seperator to use when rendering"
+        help="indicate which YAML Path seperator to use when\nrendering"
              " results; default=dot")
 
     eyaml_group = parser.add_argument_group(
-        "EYAML options", "Left unset, the EYAML keys will default to your\
-         system or user defaults.  Both keys must be set either here or in\
-         your system or user EYAML configuration file when using EYAML.")
+        "EYAML options", "Left unset, the EYAML keys will default to your"
+        "system or user defaults.\nBoth keys must be set either here or in"
+        "your system or user EYAML\nconfiguration file when using EYAML.")
     eyaml_group.add_argument(
         "-x", "--eyaml",
         default="eyaml",
@@ -68,7 +106,7 @@ def processcli():
     eyaml_group.add_argument(
         "-E", "--ignore-eyaml-values",
         action="store_true",
-        help="Do not use EYAML to compare encrypted data; rather, treat"
+        help="Do not use EYAML to compare encrypted data; rather,\ntreat"
              " ENC[...] values as regular strings")
 
     noise_group = parser.add_mutually_exclusive_group()
@@ -88,7 +126,8 @@ def processcli():
     parser.add_argument("yaml_files", metavar="YAML_FILE",
                         nargs=2,
                         help="exactly two YAML/JSON/compatible files to"
-                             " compare; use - to read one document from STDIN")
+                             " compare; use\n- to read one document from"
+                             " STDIN")
 
     return parser.parse_args()
 
@@ -111,6 +150,34 @@ def validateargs(args, log):
         log.error(
             "The --quiet|-q option suppresses all output, including that of"
             " --same|-s and --onlysame|-o, so they cannot be set together.")
+
+    # When set, the configuration file must be a readable file
+    if args.config and not (
+            isfile(args.config)
+            and access(args.config, R_OK)
+    ):
+        has_errors = True
+        log.error(
+            "INI style configuration file is not readable:  {}"
+            .format(args.config))
+
+    # When set, --privatekey must be a readable file
+    if args.privatekey and not (
+            isfile(args.privatekey)
+            and access(args.privatekey, R_OK)
+    ):
+        has_errors = True
+        log.error(
+            "EYAML private key is not a readable file:  " + args.privatekey)
+
+    # When set, --publickey must be a readable file
+    if args.publickey and not (
+            isfile(args.publickey)
+            and access(args.publickey, R_OK)
+    ):
+        has_errors = True
+        log.error(
+            "EYAML public key is not a readable file:  " + args.publickey)
 
     if has_errors:
         sys.exit(1)
@@ -149,7 +216,7 @@ def main():
     validateargs(args, log)
     exit_state = 0
     lhs_file = args.yaml_files[0]
-    rhs_file = args.yaml_files[1] if len(args.yaml_files) > 1 else "-"
+    rhs_file = args.yaml_files[1]
     lhs_yaml = get_yaml_editor()
     rhs_yaml = get_yaml_editor()
 
@@ -164,7 +231,7 @@ def main():
         sys.exit(1)
 
     diff = Differ(
-        log, lhs_document, sync_arrays=args.sync_arrays,
+        DifferConfig(log, args), log, lhs_document,
         ignore_eyaml_values=args.ignore_eyaml_values, binary=args.eyaml,
         publickey=args.publickey, privatekey=args.privatekey)
 

--- a/yamlpath/commands/yaml_get.py
+++ b/yamlpath/commands/yaml_get.py
@@ -32,13 +32,17 @@ from yamlpath.wrappers import ConsolePrinter
 def processcli():
     """Process command-line arguments."""
     parser = argparse.ArgumentParser(
-        description="Retrieves one or more values from a YAML/JSON/Compatible\
-            file at a specified YAML Path.  Output is printed to STDOUT, one\
-            line per result.  When a result is a complex data-type (Array or\
-            Hash), a JSON dump is produced to represent it.  EYAML can be\
-            employed to decrypt the values.",
-        epilog="For more information about YAML Paths, please visit\
-            https://github.com/wwkimball/yamlpath."
+        description=(
+            "Retrieves one or more values from a YAML/JSON/Compatible"
+            " file at a specified YAML Path.  Output is printed to STDOUT, one"
+            " line per result.  When a result is a complex data-type (Array or"
+            " Hash), a JSON dump is produced to represent it.  EYAML can be"
+            " employed to decrypt the values."),
+        epilog=(
+            "For more information about YAML Paths, please visit"
+            " https://github.com/wwkimball/yamlpath/wiki.  To report issues"
+            " with this tool or to request enhancements, please visit"
+            " https://github.com/wwkimball/yamlpath/issues.")
     )
     parser.add_argument("-V", "--version", action="version",
                         version="%(prog)s " + YAMLPATH_VERSION)

--- a/yamlpath/commands/yaml_get.py
+++ b/yamlpath/commands/yaml_get.py
@@ -14,7 +14,7 @@ import json
 from os import access, R_OK
 from os.path import isfile
 
-from yamlpath.common import YAMLPATH_VERSION
+from yamlpath import __version__ as YAMLPATH_VERSION
 from yamlpath.func import (
     get_yaml_data,
     get_yaml_editor,

--- a/yamlpath/commands/yaml_merge.py
+++ b/yamlpath/commands/yaml_merge.py
@@ -37,34 +37,42 @@ def processcli():
     """Process command-line arguments."""
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawTextHelpFormatter,
-        description=("Merges two or more YAML/JSON/Compatible documents"
-                    + "together, including\ncomplex data provided via STDIN."),
+        description="Merges two or more single- or multi-document"
+                    " YAML/JSON/Compatible documents\ntogether, including"
+                    " complex data provided via STDIN.",
         epilog="""
-            The CONFIG file is an INI file with up to three sections:
-            [defaults] Sets equivalents of -a|--anchors, -A|--arrays,
-                       -H|--hashes, and -O|--aoh.
-            [rules]    Each entry is a YAML Path assigning -A|--arrays,
-                       -H|--hashes, or -O|--aoh for precise nodes.
-            [keys]     Wherever -O|--aoh=DEEP, each entry is treated as a
-                       record with an identity key.  In order to match RHS
-                       records to LHS records, a key must be known and is
-                       identified on a YAML Path basis via this section.
-                       Where not specified, the first attribute of the first
-                       record in the Array-of-Hashes is presumed the identity
-                       key for all records in the set.
+configuration file:
+  The CONFIG file is an INI file with up to three sections:
+  [defaults] Sets equivalents of --anchors|-a, --arrays|-A, --hashes|-H, and
+             --aoh|-O.
+  [rules]    Each entry is a YAML Path assigning --arrays|-A, --hashes|-H,
+             or --aoh|-O for precise nodes.
+  [keys]     Wherever --aoh=DEEP (or -O deep), each entry is treated as a
+             record with an identity key.  In order to match RHS records to
+             LHS records, a key must be known and is identified on a YAML
+             Path basis via this section.  Where not specified, the first
+             attribute of the first record in the Array-of-Hashes is presumed
+             the identity key for all records in the set.
 
-            The left-to-right order of YAML_FILEs is significant.  Except
-            when this behavior is deliberately altered by your options, data
-            from files on the right overrides data in files to their left.
-            Only one input file may be the - pseudo-file (read from STDIN).
-            When no YAML_FILEs are provided, - will be inferred as long as you
-            are running this program without a TTY (unless you set
-            --nostdin|-S).  Any file, including input from STDIN, may be a
-            multi-document YAML or JSON file.
+input files:
+  The left-to-right order of YAML_FILEs is significant.  Except when this
+  behavior is deliberately altered by your options, data from files on the
+  right overrides data in files to their left.
 
-            For more information about YAML Paths, please visit
-            https://github.com/wwkimball/yamlpath."""
-    )
+  Only one input file may be the - pseudo-file (read from STDIN).  When no
+  YAML_FILEs are provided, - will be inferred as long as you are running
+  this program without a TTY (unless you set --nostdin|-S).
+
+  Any file, including input from STDIN, may be a multi-document YAML, JSON,
+  or compatible file.
+
+For more information about YAML Paths, please visit
+https://github.com/wwkimball/yamlpath/wiki.
+
+To report issues with this tool or to request enhancements, please visit
+https://github.com/wwkimball/yamlpath/issues.
+""")
+
     parser.add_argument("-V", "--version", action="version",
                         version="%(prog)s " + YAMLPATH_VERSION)
 

--- a/yamlpath/commands/yaml_merge.py
+++ b/yamlpath/commands/yaml_merge.py
@@ -14,7 +14,7 @@ from os.path import isfile, exists
 from shutil import copy2
 from typing import Any
 
-from yamlpath.common import YAMLPATH_VERSION
+from yamlpath import __version__ as YAMLPATH_VERSION
 from yamlpath.merger.enums import (
     AnchorConflictResolutions,
     AoHMergeOpts,

--- a/yamlpath/commands/yaml_paths.py
+++ b/yamlpath/commands/yaml_paths.py
@@ -16,7 +16,7 @@ from typing import Any, Generator, List, Optional, Tuple
 
 from ruamel.yaml.comments import CommentedSeq, CommentedMap
 
-from yamlpath.common import YAMLPATH_VERSION
+from yamlpath import __version__ as YAMLPATH_VERSION
 from yamlpath.func import (
     create_searchterms_from_pathattributes,
     escape_path_section,

--- a/yamlpath/commands/yaml_paths.py
+++ b/yamlpath/commands/yaml_paths.py
@@ -42,14 +42,19 @@ def processcli():
     """Process command-line arguments."""
     search_ops = ", ".join(PathSearchMethods.get_operators()) + ", or !"
     parser = argparse.ArgumentParser(
-        description="Returns zero or more YAML Paths indicating where in given\
-            YAML/JSON/Compatible data one or more search expressions match.\
-            Values, keys, and/or anchors can be searched.  EYAML can be\
-            employed to search encrypted values.",
-        epilog="A search or exception EXPRESSION takes the form of a YAML Path\
-            search operator -- {} -- followed by the search term, omitting the\
-            left-hand operand.  For more information about YAML Paths, please\
-            visit https://github.com/wwkimball/yamlpath.".format(search_ops)
+        description=(
+            "Returns zero or more YAML Paths indicating where in given"
+            " YAML/JSON/Compatible data one or more search expressions match."
+            "  Values, keys, and/or anchors can be searched.  EYAML can be"
+            " employed to search encrypted values."),
+        epilog=(
+            "A search or exception EXPRESSION takes the form of a YAML Path"
+            " search operator -- {} -- followed by the search term, omitting"
+            " the left-hand operand.  For more information about YAML Paths,"
+            " please visit https://github.com/wwkimball/yamlpath/wiki.  To"
+            " report issues with this tool or to request enhancements, please"
+            " visit https://github.com/wwkimball/yamlpath/issues.")
+            .format(search_ops)
     )
     parser.add_argument("-V", "--version", action="version",
                         version="%(prog)s " + YAMLPATH_VERSION)

--- a/yamlpath/commands/yaml_set.py
+++ b/yamlpath/commands/yaml_set.py
@@ -43,16 +43,20 @@ from yamlpath.wrappers import ConsolePrinter, NodeCoords
 def processcli():
     """Process command-line arguments."""
     parser = argparse.ArgumentParser(
-        description="Changes one or more Scalar values in a\
-            YAML/JSON/Compatible document at a specified YAML Path.  Matched\
-            values can be checked before they are replaced to mitigate\
-            accidental change.  When matching singular results, the value can\
-            be archived to another key before it is replaced.  Further, EYAML\
-            can be employed to encrypt the new values and/or decrypt an old\
-            value before checking it.",
-        epilog="When no changes are made, no backup is created, even when\
-            -b/--backup is specified.  For more information about YAML Paths,\
-            please visit https://github.com/wwkimball/yamlpath."
+        description=(
+            "Changes one or more Scalar values in a YAML/JSON/Compatible"
+            " document at a specified YAML Path.  Matched values can be"
+            " checked before they are replaced to mitigate accidental change."
+            "  When matching singular results, the value can be archived to"
+            " another key before it is replaced.  Further, EYAML can be"
+            " employed to encrypt the new values and/or decrypt an old value"
+            " before checking it."),
+        epilog=(
+            "When no changes are made, no backup is created, even when"
+            " -b/--backup is specified.  For more information about YAML"
+            " Paths, please visit https://github.com/wwkimball/yamlpath/wiki."
+            "  To report issues with this tool or to request enhancements,"
+            " please visit https://github.com/wwkimball/yamlpath/issues.")
     )
     parser.add_argument("-V", "--version", action="version",
                         version="%(prog)s " + YAMLPATH_VERSION)
@@ -84,7 +88,8 @@ def processcli():
     input_group.add_argument(
         "-D", "--delete",
         action="store_true",
-        help="delete rather than change target node(s)")
+        help="delete rather than change target node(s); implies"
+             " --mustexist|-m")
 
     parser.add_argument(
         "-F", "--format",

--- a/yamlpath/commands/yaml_set.py
+++ b/yamlpath/commands/yaml_set.py
@@ -21,7 +21,7 @@ from shutil import copy2, copyfileobj
 from pathlib import Path
 
 
-from yamlpath.common import YAMLPATH_VERSION
+from yamlpath import __version__ as YAMLPATH_VERSION
 from yamlpath.func import (
     clone_node,
     build_next_node,

--- a/yamlpath/commands/yaml_validate.py
+++ b/yamlpath/commands/yaml_validate.py
@@ -36,11 +36,14 @@ def processcli():
     """Process command-line arguments."""
     parser = argparse.ArgumentParser(
         description="Validate YAML, JSON, and compatible files.",
-        epilog="Except when suppressing all report output with --quiet|-q,"
+        epilog=(
+            "Except when suppressing all report output with --quiet|-q,"
             " validation issues are printed to STDOUT (not STDERR).  Further,"
             " the exit-state will report 0 when there are no issues, 1 when"
             " there is an issue with the supplied command-line arguments, or 2"
-            " when validation has failed for any document."
+            " when validation has failed for any document.  To report issues"
+            " with this tool or to request enhancements, please visit"
+            " https://github.com/wwkimball/yamlpath/issues.")
     )
     parser.add_argument("-V", "--version", action="version",
                         version="%(prog)s " + YAMLPATH_VERSION)

--- a/yamlpath/commands/yaml_validate.py
+++ b/yamlpath/commands/yaml_validate.py
@@ -6,7 +6,7 @@ Copyright 2020 William W. Kimball, Jr. MBA MSIS
 import sys
 import argparse
 
-from yamlpath.common import YAMLPATH_VERSION
+from yamlpath import __version__ as YAMLPATH_VERSION
 from yamlpath.wrappers import ConsolePrinter
 from yamlpath.func import get_yaml_editor, get_yaml_multidoc_data
 

--- a/yamlpath/common.py
+++ b/yamlpath/common.py
@@ -1,2 +1,0 @@
-"""Values common to various yamlpath components."""
-YAMLPATH_VERSION = "3.3.0"

--- a/yamlpath/common.py
+++ b/yamlpath/common.py
@@ -1,2 +1,2 @@
 """Values common to various yamlpath components."""
-YAMLPATH_VERSION = "3.2.0"
+YAMLPATH_VERSION = "3.3.0"

--- a/yamlpath/differ/__init__.py
+++ b/yamlpath/differ/__init__.py
@@ -1,0 +1,3 @@
+"""YAML Path diff calculation classes."""
+from .diffentry import DiffEntry
+from .differ import Differ

--- a/yamlpath/differ/__init__.py
+++ b/yamlpath/differ/__init__.py
@@ -1,3 +1,4 @@
 """YAML Path diff calculation classes."""
 from .diffentry import DiffEntry
+from .differconfig import DifferConfig
 from .differ import Differ

--- a/yamlpath/differ/diffentry.py
+++ b/yamlpath/differ/diffentry.py
@@ -1,0 +1,127 @@
+"""
+Implement DiffEntry.
+
+Copyright 2020 William W. Kimball, Jr. MBA MSIS
+"""
+import json
+from typing import Any
+
+from ruamel.yaml.comments import CommentedBase
+
+from yamlpath.enums import PathSeperators
+from yamlpath import YAMLPath
+from yamlpath.func import stringify_dates
+from .enums.diffactions import DiffActions
+
+
+class DiffEntry:
+    """One entry of a diff."""
+
+    def __init__(
+        self, action: DiffActions, path: YAMLPath, lhs: Any, rhs: Any,
+        **kwargs
+    ):
+        """Initiate a new DiffEntry."""
+        self._action: DiffActions = action
+        self._path: YAMLPath = path
+        self._lhs: Any = lhs
+        self._rhs: Any = rhs
+        self._set_index(lhs, rhs, **kwargs)
+        self._verbose = False
+
+    def _set_index(self, lhs: Any, rhs: Any, **kwargs) -> Any:
+        """Build the sortable index for this entry."""
+        lhs_lc = DiffEntry._get_index(lhs, kwargs.pop("lhs_parent", None))
+        rhs_lc = DiffEntry._get_index(rhs, kwargs.pop("rhs_parent", None))
+        lhs_line = float(lhs_lc)
+        rhs_line = float(rhs_lc)
+        if lhs_line < rhs_line:
+            lhs_lc, rhs_lc = rhs_lc, lhs_lc
+        self._index = "{}.{}".format(lhs_lc, rhs_lc)
+
+    def __str__(self) -> str:
+        """Get the string representation of this object."""
+        diffaction = self._action
+        path = self._path if self._path else "-"
+        output = "{}{} {}\n".format(
+            diffaction, self._index if self.verbose else "", path)
+        if diffaction is DiffActions.ADD:
+            output += DiffEntry._present_data(self._rhs, ">")
+        elif diffaction is DiffActions.CHANGE:
+            output += "{}\n---\n{}".format(
+                DiffEntry._present_data(self._lhs, "<"),
+                DiffEntry._present_data(self._rhs, ">"))
+        elif diffaction is DiffActions.DELETE:
+            output += "{}".format(DiffEntry._present_data(self._lhs, "<"))
+        else:
+            output += "{}".format(DiffEntry._present_data(self._lhs, "="))
+        return output
+
+    @property
+    def action(self) -> DiffActions:
+        """Get the action of this difference (read-only)."""
+        return self._action
+
+    @property
+    def index(self) -> str:
+        """Get the sortable index for this entry (read-only)."""
+        return self._index
+
+    @property
+    def pathsep(self) -> PathSeperators:
+        """Seperator used to delimit reported YAML Paths (accessor)."""
+        return self._path.seperator
+
+    @pathsep.setter
+    def pathsep(self, value: PathSeperators) -> None:
+        """Seperator used to delimit reported YAML Paths (mutator)."""
+        # No unnecessary changes
+        if value is not self.pathsep:
+            self._path.seperator = value
+
+    @property
+    def verbose(self) -> bool:
+        """Output verbosity (accessor)."""
+        return self._verbose
+
+    @verbose.setter
+    def verbose(self, value: bool) -> None:
+        """Output verbosity (mutator)."""
+        # No unnecessary changes
+        if value != self.verbose:
+            self._verbose = value
+
+    @classmethod
+    def _jsonify_data(cls, data: Any) -> str:
+        """Generate JSON representation of data."""
+        if isinstance(data, (list, dict)):
+            return json.dumps(stringify_dates(data))
+        return str(data)
+
+    @classmethod
+    def _get_lc(cls, data: Any) -> str:
+        """Get the line.column of a data element."""
+        data_lc = "0.0"
+        if isinstance(data, CommentedBase):
+            dlc = data.lc
+            data_lc = "{}.{}".format(
+                dlc.line if dlc.line is not None else 0,
+                dlc.col if dlc.col is not None else 0
+            )
+        return data_lc
+
+    @classmethod
+    def _get_index(cls, data: Any, parent: Any) -> str:
+        """Get the document index of a data element."""
+        data_lc = DiffEntry._get_lc(data)
+        if data_lc == "0.0":
+            data_lc = DiffEntry._get_lc(parent)
+        return data_lc
+
+    @classmethod
+    def _present_data(cls, data: Any, prefix: str) -> str:
+        """Stringify data."""
+        return "{} {}".format(
+            prefix,
+            DiffEntry._jsonify_data(data).strip().replace(
+                "\n", "\n{} ".format(prefix)))

--- a/yamlpath/differ/diffentry.py
+++ b/yamlpath/differ/diffentry.py
@@ -33,11 +33,15 @@ class DiffEntry:
         """Build the sortable index for this entry."""
         lhs_lc = DiffEntry._get_index(lhs, kwargs.pop("lhs_parent", None))
         rhs_lc = DiffEntry._get_index(rhs, kwargs.pop("rhs_parent", None))
+        lhs_iteration = kwargs.pop("lhs_iteration", 0)
+        rhs_iteration = kwargs.pop("rhs_iteration", 0)
+        lhs_iteration = 0 if lhs_iteration is None else lhs_iteration
+        rhs_iteration = 0 if rhs_iteration is None else rhs_iteration
         lhs_line = float(lhs_lc)
-        rhs_line = float(rhs_lc)
-        if lhs_line < rhs_line:
+        if lhs_line == 0.0 or self.action is DiffActions.ADD:
             lhs_lc, rhs_lc = rhs_lc, lhs_lc
-        self._index = "{}.{}".format(lhs_lc, rhs_lc)
+        self._index = "{}.{}.{}.{}".format(
+            lhs_lc, lhs_iteration, rhs_lc, rhs_iteration)
 
     def __str__(self) -> str:
         """Get the string representation of this object."""
@@ -61,6 +65,16 @@ class DiffEntry:
     def action(self) -> DiffActions:
         """Get the action of this difference (read-only)."""
         return self._action
+
+    @property
+    def path(self) -> YAMLPath:
+        """Get the YAML Path of this difference (read-only)."""
+        return self._path
+
+    @property
+    def lhs(self) -> Any:
+        """Get the LHS value of this difference (read-only)."""
+        return self._lhs
 
     @property
     def index(self) -> str:

--- a/yamlpath/differ/differ.py
+++ b/yamlpath/differ/differ.py
@@ -6,6 +6,7 @@ Copyright 2020 William W. Kimball, Jr. MBA MSIS
 from itertools import zip_longest
 from typing import Any, Dict, Generator, List, Optional, Tuple
 
+from yamlpath.func import escape_path_section
 from yamlpath import YAMLPath
 from yamlpath.wrappers import ConsolePrinter, NodeCoords
 from yamlpath.eyaml import EYAMLProcessor
@@ -62,14 +63,14 @@ class Differ:
             lhs_iteration = -1
             for key, val in data.items():
                 lhs_iteration += 1
-                next_path = YAMLPath(path).append(key)
+                next_path = path + escape_path_section(key, path.seperator)
                 self._diffs.append(
                     DiffEntry(
                         DiffActions.DELETE, next_path, val, None,
                         lhs_parent=data, lhs_iteration=lhs_iteration))
         elif isinstance(data, list):
             for idx, ele in enumerate(data):
-                next_path = YAMLPath(path).append("[{}]".format(idx))
+                next_path = path + "[{}]".format(idx)
                 self._diffs.append(
                     DiffEntry(
                         DiffActions.DELETE, next_path, ele, None,
@@ -86,14 +87,14 @@ class Differ:
             rhs_iteration = -1
             for key, val in data.items():
                 rhs_iteration += 1
-                next_path = YAMLPath(path).append(key)
+                next_path = path + escape_path_section(key, path.seperator)
                 self._diffs.append(
                     DiffEntry(
                         DiffActions.ADD, next_path, None, val,
                         rhs_parent=data, rhs_iteration=rhs_iteration))
         elif isinstance(data, list):
             for idx, ele in enumerate(data):
-                next_path = YAMLPath(path).append("[{}]".format(idx))
+                next_path = path + "[{}]".format(idx)
                 self._diffs.append(
                     DiffEntry(
                         DiffActions.ADD, next_path, None, ele,
@@ -168,7 +169,7 @@ class Differ:
             (key, val) for key, val in rhs.items()
             if key in lhs and key in rhs
         ]:
-            next_path = YAMLPath(path).append(key)
+            next_path = path + escape_path_section(key, path.seperator)
             self._diff_between(
                 next_path, lhs[key], val,
                 lhs_parent=lhs, lhs_iteration=lhs_key_indicies[key],
@@ -177,7 +178,7 @@ class Differ:
 
         # Look for deleted keys
         for key in lhs_keys - rhs_keys:
-            next_path = YAMLPath(path).append(key)
+            next_path = path + escape_path_section(key, path.seperator)
             self._diffs.append(
                 DiffEntry(
                     DiffActions.DELETE, next_path, lhs[key], None,
@@ -186,7 +187,7 @@ class Differ:
 
         # Look for new keys
         for key in rhs_keys - lhs_keys:
-            next_path = YAMLPath(path).append(key)
+            next_path = path + escape_path_section(key, path.seperator)
             self._diffs.append(
                 DiffEntry(
                     DiffActions.ADD, next_path, None, rhs[key],
@@ -216,7 +217,7 @@ class Differ:
 
         for (lidx, lele, ridx, rele) in syn_pairs:
             if lele is None:
-                next_path = YAMLPath(path).append("[{}]".format(ridx))
+                next_path = path + "[{}]".format(ridx)
                 diff_action = DiffActions.ADD
                 opposite_val = None
                 pop_index = -1
@@ -239,14 +240,14 @@ class Differ:
                     lhs_parent=lhs, lhs_iteration=lidx,
                     rhs_parent=rhs, rhs_iteration=ridx))
             elif rele is None:
-                next_path = YAMLPath(path).append("[{}]".format(lidx))
+                next_path = path + "[{}]".format(lidx)
                 self._diffs.append(
                     DiffEntry(
                         DiffActions.DELETE, next_path, lele, None,
                         lhs_parent=lhs, lhs_iteration=lidx,
                         rhs_parent=rhs, rhs_iteration=ridx))
             else:
-                next_path = YAMLPath(path).append("[{}]".format(lidx))
+                next_path = path + "[{}]".format(lidx)
                 self._diff_between(
                     next_path, lele, rele,
                     lhs_parent=lhs, lhs_iteration=lidx,
@@ -275,7 +276,7 @@ class Differ:
         idx = 0
         diff_deeply = kwargs.pop("diff_deeply", True)
         for (lele, rele) in zip_longest(lhs, rhs):
-            next_path = YAMLPath(path).append("[{}]".format(idx))
+            next_path = path + "[{}]".format(idx)
             idx += 1
             if lele is None:
                 self._diffs.append(
@@ -360,14 +361,14 @@ class Differ:
 
         for (lidx, lele, ridx, rele) in syn_pairs:
             if lele is None:
-                next_path = YAMLPath(path).append("[{}]".format(ridx))
+                next_path = path + "[{}]".format(ridx)
                 self._diffs.append(
                     DiffEntry(
                         DiffActions.ADD, next_path, None, rele,
                         lhs_parent=lhs, lhs_iteration=lidx,
                         rhs_parent=rhs, rhs_iteration=ridx))
             elif rele is None:
-                next_path = YAMLPath(path).append("[{}]".format(lidx))
+                next_path = path + "[{}]".format(lidx)
                 self._diffs.append(
                     DiffEntry(
                         DiffActions.DELETE, next_path, lele, None,
@@ -375,7 +376,7 @@ class Differ:
                         rhs_parent=rhs, rhs_iteration=ridx))
             else:
                 if deep_diff:
-                    next_path = YAMLPath(path).append("[{}]".format(ridx))
+                    next_path = path + "[{}]".format(ridx)
                     self._diff_between(
                         next_path, lele, rele,
                         lhs_parent=lhs, lhs_iteration=lidx,
@@ -383,7 +384,7 @@ class Differ:
                         parentref=ridx)
                 else:
                     # KEY-based comparisons
-                    next_path = YAMLPath(path).append("[{}]".format(lidx))
+                    next_path = path + "[{}]".format(lidx)
                     diff_action = (DiffActions.SAME
                                   if lele == rele
                                   else DiffActions.CHANGE)

--- a/yamlpath/differ/differ.py
+++ b/yamlpath/differ/differ.py
@@ -1,0 +1,262 @@
+"""
+Implement YAML document Differ.
+
+Copyright 2020 William W. Kimball, Jr. MBA MSIS
+"""
+from itertools import zip_longest
+from typing import Any, Generator, List
+
+from yamlpath import YAMLPath
+from yamlpath.wrappers import ConsolePrinter
+from yamlpath.eyaml import EYAMLProcessor
+from .enums.diffactions import DiffActions
+from .diffentry import DiffEntry
+
+
+class Differ:
+    """Calculates the difference between two YAML documents."""
+
+    def __init__(
+        self, logger: ConsolePrinter, document: Any, **kwargs
+    ) -> None:
+        """
+        Instantiate this class into an object.
+
+        Parameters:
+        1. logger (ConsolePrinter) Instance of ConsoleWriter or subclass
+        2. document (Any) The basis document
+
+        Returns:  N/A
+
+        Raises:  N/A
+        """
+        ignore_eyaml = kwargs.pop("ignore_eyaml_values", True)
+        self.logger: ConsolePrinter = logger
+        self._data: Any = document
+        self._diffs: List[DiffEntry] = []
+        self._sync_arrays = kwargs.pop("sync_arrays", False)
+        self._ignore_eyaml = ignore_eyaml
+        self._eyamlproc = (None
+                           if ignore_eyaml
+                           else EYAMLProcessor(logger, document, **kwargs))
+
+    def compare_to(self, document: Any) -> None:
+        """Perform the diff calculation."""
+        self._diffs.clear()
+        self._diff_between(YAMLPath(), self._data, document)
+
+    def get_report(self) -> Generator[DiffEntry, None, None]:
+        """Get the diff report."""
+        for entry in sorted(
+            self._diffs, key=lambda e: [int(i) for i in e.index.split('.')]
+        ):
+            yield entry
+
+    def _purge_document(self, path: YAMLPath, data: Any):
+        """Delete every node in the document."""
+        if isinstance(data, dict):
+            for key, val in data.items():
+                next_path = YAMLPath(path).append(key)
+                self._diffs.append(
+                    DiffEntry(
+                        DiffActions.DELETE, next_path, val, None,
+                        lhs_parent=data))
+        elif isinstance(data, list):
+            for idx, ele in enumerate(data):
+                next_path = YAMLPath(path).append("[{}]".format(idx))
+                self._diffs.append(
+                    DiffEntry(
+                        DiffActions.DELETE, next_path, ele, None,
+                        lhs_parent=data))
+        else:
+            if data is not None:
+                self._diffs.append(
+                    DiffEntry(DiffActions.DELETE, path, data, None)
+                )
+
+    def _add_everything(self, path: YAMLPath, data: Any) -> None:
+        """Add every node in the document."""
+        if isinstance(data, dict):
+            for key, val in data.items():
+                next_path = YAMLPath(path).append(key)
+                self._diffs.append(
+                    DiffEntry(
+                        DiffActions.ADD, next_path, None, val,
+                        rhs_parent=data))
+        elif isinstance(data, list):
+            for idx, ele in enumerate(data):
+                next_path = YAMLPath(path).append("[{}]".format(idx))
+                self._diffs.append(
+                    DiffEntry(
+                        DiffActions.ADD, next_path, None, ele,
+                        rhs_parent=data))
+        else:
+            if data is not None:
+                self._diffs.append(
+                    DiffEntry(DiffActions.ADD, path, None, data)
+                )
+
+    def _diff_between(
+        self, path: YAMLPath, lhs: Any, rhs: Any, **kwargs
+    ) -> None:
+        """Calculate the differences between two document nodes."""
+        # If the roots are different, delete all LHS and add all RHS.
+        lhs_is_dict = isinstance(lhs, dict)
+        lhs_is_list = isinstance(lhs, list)
+        lhs_is_scalar = not (lhs_is_dict or lhs_is_list)
+        rhs_is_dict = isinstance(rhs, dict)
+        rhs_is_list = isinstance(rhs, list)
+        rhs_is_scalar = not (rhs_is_dict or rhs_is_list)
+        same_types = (
+            (lhs_is_dict and rhs_is_dict)
+            or (lhs_is_list and rhs_is_list)
+            or (lhs_is_scalar and rhs_is_scalar)
+        )
+        if same_types:
+            if lhs_is_dict:
+                self._diff_dicts(path, lhs, rhs)
+            elif lhs_is_list:
+                self._diff_lists(path, lhs, rhs)
+            else:
+                self._diff_scalars(path, lhs, rhs, **kwargs)
+        else:
+            self._purge_document(path, lhs)
+            self._add_everything(path, rhs)
+
+    def _diff_dicts(self, path: YAMLPath, lhs: dict, rhs: dict) -> None:
+        """Diff two dicts."""
+        lhs_keys = set(lhs)
+        rhs_keys = set(rhs)
+
+        # Look for deleted keys
+        for key in lhs_keys - rhs_keys:
+            next_path = YAMLPath(path).append(key)
+            self._diffs.append(
+                DiffEntry(
+                    DiffActions.DELETE, next_path, lhs[key], None,
+                    lhs_parent=lhs, rhs_parent=rhs))
+
+        # Look for new keys
+        for key in rhs_keys - lhs_keys:
+            next_path = YAMLPath(path).append(key)
+            self._diffs.append(
+                DiffEntry(
+                    DiffActions.ADD, next_path, None, rhs[key],
+                    lhs_parent=lhs, rhs_parent=rhs))
+
+        # Recurse into the rest
+        for key, val in [
+            (key, val) for key, val in rhs.items()
+            if key in lhs and key in rhs
+        ]:
+            next_path = YAMLPath(path).append(key)
+            self._diff_between(
+                next_path, lhs[key], val, lhs_parent=lhs, rhs_parent=rhs)
+
+    def _diff_lists(self, path: YAMLPath, lhs: list, rhs: list) -> None:
+        """Diff two lists."""
+        if self._sync_arrays:
+            self._diff_synced_lists(path, lhs, rhs)
+            return
+
+        idx = 0
+        for (lele, rele) in zip_longest(lhs, rhs):
+            next_path = YAMLPath(path).append("[{}]".format(idx))
+            idx += 1
+            if lele is None:
+                self._diffs.append(
+                    DiffEntry(
+                        DiffActions.ADD, next_path, None, rele,
+                        lhs_parent=lhs, rhs_parent=rhs))
+            elif rele is None:
+                self._diffs.append(
+                    DiffEntry(
+                        DiffActions.DELETE, next_path, lele, None,
+                        lhs_parent=lhs, rhs_parent=rhs))
+            else:
+                self._diff_between(
+                    next_path, lele, rele, lhs_parent=lhs, rhs_parent=rhs)
+
+    def _diff_synced_lists(self, path: YAMLPath, lhs: list, rhs: list) -> None:
+        """Diff two synchronized lists."""
+        # lhs = [1, 2, 2, 3]
+        # rhs = [2, 3, 3, 4]
+        # syn = [[1, None], [2, 2], [2, None], [3, 3], [None, 3], [None, 4]]
+        # lsy = [1,    2, 2,    3, None, None]
+        # rsy = [None, 2, None, 3, 3,    4]
+        debug_path = path if path else "/"
+        self.logger.debug(
+            "Synchronizing LHS Array elements at YAML Path, {}:"
+            .format(debug_path),
+            prefix="Differ::_diff_syncd_lists:  ",
+            data=lhs)
+        self.logger.debug(
+            "Synchronizing RHS Array elements at YAML Path, {}:"
+            .format(debug_path),
+            prefix="Differ::_diff_syncd_lists:  ",
+            data=rhs)
+
+        rhs_reduced = rhs.copy()
+        syn_pairs = []
+        for lhs_ele in lhs:
+            del_index = -1
+            for idx, ele in enumerate(rhs_reduced):
+                if ele == lhs_ele:
+                    del_index = idx
+                    break
+            if del_index > -1:
+                rhs_ele = rhs_reduced.pop(del_index)
+                syn_pairs.append((lhs_ele, rhs_ele))
+            else:
+                syn_pairs.append((lhs_ele, None))
+        for rhs_ele in rhs_reduced:
+            syn_pairs.append((None, rhs_ele))
+
+        self.logger.debug(
+            "Got synchronized pairs of Array elements at YAML Path, {}:"
+            .format(debug_path),
+            prefix="Differ::_diff_syncd_lists:  ",
+            data=syn_pairs)
+
+        idx = 0
+        for (lele, rele) in syn_pairs:
+            next_path = YAMLPath(path).append("[{}]".format(idx))
+            idx += 1
+            if lele is None:
+                self._diffs.append(
+                    DiffEntry(
+                        DiffActions.ADD, next_path, None, rele,
+                        lhs_parent=lhs, rhs_parent=rhs))
+            elif rele is None:
+                self._diffs.append(
+                    DiffEntry(
+                        DiffActions.DELETE, next_path, lele, None,
+                        lhs_parent=lhs, rhs_parent=rhs))
+            else:
+                self._diff_between(
+                    next_path, lele, rele, lhs_parent=lhs, rhs_parent=rhs)
+
+    def _diff_scalars(
+        self, path: YAMLPath, lhs: Any, rhs: Any, **kwargs
+    ) -> None:
+        """Diff two Scalar values."""
+        lhs_val = lhs
+        rhs_val = rhs
+        if (not self._ignore_eyaml
+            and isinstance(self._eyamlproc, EYAMLProcessor)
+        ):
+            if self._eyamlproc.is_eyaml_value(lhs):
+                lhs_val = self._eyamlproc.decrypt_eyaml(lhs)
+                lhs = lhs.replace("\r", "").replace(" ", "")
+            if self._eyamlproc.is_eyaml_value(rhs):
+                rhs_val = self._eyamlproc.decrypt_eyaml(rhs)
+                rhs = rhs.replace("\r", "").replace(" ", "")
+
+        if lhs_val == rhs_val:
+            self._diffs.append(
+                DiffEntry(DiffActions.SAME, path, lhs, rhs, **kwargs)
+            )
+        else:
+            self._diffs.append(
+                DiffEntry(DiffActions.CHANGE, path, lhs, rhs, **kwargs)
+            )

--- a/yamlpath/differ/differ.py
+++ b/yamlpath/differ/differ.py
@@ -4,20 +4,22 @@ Implement YAML document Differ.
 Copyright 2020 William W. Kimball, Jr. MBA MSIS
 """
 from itertools import zip_longest
-from typing import Any, Generator, List
+from typing import Any, Dict, Generator, List, Optional, Tuple
 
 from yamlpath import YAMLPath
-from yamlpath.wrappers import ConsolePrinter
+from yamlpath.wrappers import ConsolePrinter, NodeCoords
 from yamlpath.eyaml import EYAMLProcessor
-from .enums.diffactions import DiffActions
+from .enums import ArrayDiffOpts, AoHDiffOpts, DiffActions
 from .diffentry import DiffEntry
+from .differconfig import DifferConfig
 
 
 class Differ:
     """Calculates the difference between two YAML documents."""
 
     def __init__(
-        self, logger: ConsolePrinter, document: Any, **kwargs
+        self, config: DifferConfig, logger: ConsolePrinter, document: Any,
+        **kwargs
     ) -> None:
         """
         Instantiate this class into an object.
@@ -31,11 +33,12 @@ class Differ:
         Raises:  N/A
         """
         ignore_eyaml = kwargs.pop("ignore_eyaml_values", True)
+
+        self.config: DifferConfig = config
         self.logger: ConsolePrinter = logger
         self._data: Any = document
         self._diffs: List[DiffEntry] = []
-        self._sync_arrays = kwargs.pop("sync_arrays", False)
-        self._ignore_eyaml = ignore_eyaml
+        self._ignore_eyaml: bool = ignore_eyaml
         self._eyamlproc = (None
                            if ignore_eyaml
                            else EYAMLProcessor(logger, document, **kwargs))
@@ -43,6 +46,7 @@ class Differ:
     def compare_to(self, document: Any) -> None:
         """Perform the diff calculation."""
         self._diffs.clear()
+        self.config.prepare(document)
         self._diff_between(YAMLPath(), self._data, document)
 
     def get_report(self) -> Generator[DiffEntry, None, None]:
@@ -55,19 +59,21 @@ class Differ:
     def _purge_document(self, path: YAMLPath, data: Any):
         """Delete every node in the document."""
         if isinstance(data, dict):
+            lhs_iteration = -1
             for key, val in data.items():
+                lhs_iteration += 1
                 next_path = YAMLPath(path).append(key)
                 self._diffs.append(
                     DiffEntry(
                         DiffActions.DELETE, next_path, val, None,
-                        lhs_parent=data))
+                        lhs_parent=data, lhs_iteration=lhs_iteration))
         elif isinstance(data, list):
             for idx, ele in enumerate(data):
                 next_path = YAMLPath(path).append("[{}]".format(idx))
                 self._diffs.append(
                     DiffEntry(
                         DiffActions.DELETE, next_path, ele, None,
-                        lhs_parent=data))
+                        lhs_parent=data, lhs_iteration=idx))
         else:
             if data is not None:
                 self._diffs.append(
@@ -77,169 +83,40 @@ class Differ:
     def _add_everything(self, path: YAMLPath, data: Any) -> None:
         """Add every node in the document."""
         if isinstance(data, dict):
+            rhs_iteration = -1
             for key, val in data.items():
+                rhs_iteration += 1
                 next_path = YAMLPath(path).append(key)
                 self._diffs.append(
                     DiffEntry(
                         DiffActions.ADD, next_path, None, val,
-                        rhs_parent=data))
+                        rhs_parent=data, rhs_iteration=rhs_iteration))
         elif isinstance(data, list):
             for idx, ele in enumerate(data):
                 next_path = YAMLPath(path).append("[{}]".format(idx))
                 self._diffs.append(
                     DiffEntry(
                         DiffActions.ADD, next_path, None, ele,
-                        rhs_parent=data))
+                        rhs_parent=data, rhs_iteration=idx))
         else:
             if data is not None:
                 self._diffs.append(
                     DiffEntry(DiffActions.ADD, path, None, data)
                 )
 
-    def _diff_between(
-        self, path: YAMLPath, lhs: Any, rhs: Any, **kwargs
-    ) -> None:
-        """Calculate the differences between two document nodes."""
-        # If the roots are different, delete all LHS and add all RHS.
-        lhs_is_dict = isinstance(lhs, dict)
-        lhs_is_list = isinstance(lhs, list)
-        lhs_is_scalar = not (lhs_is_dict or lhs_is_list)
-        rhs_is_dict = isinstance(rhs, dict)
-        rhs_is_list = isinstance(rhs, list)
-        rhs_is_scalar = not (rhs_is_dict or rhs_is_list)
-        same_types = (
-            (lhs_is_dict and rhs_is_dict)
-            or (lhs_is_list and rhs_is_list)
-            or (lhs_is_scalar and rhs_is_scalar)
-        )
-        if same_types:
-            if lhs_is_dict:
-                self._diff_dicts(path, lhs, rhs)
-            elif lhs_is_list:
-                self._diff_lists(path, lhs, rhs)
-            else:
-                self._diff_scalars(path, lhs, rhs, **kwargs)
-        else:
-            self._purge_document(path, lhs)
-            self._add_everything(path, rhs)
-
-    def _diff_dicts(self, path: YAMLPath, lhs: dict, rhs: dict) -> None:
-        """Diff two dicts."""
-        lhs_keys = set(lhs)
-        rhs_keys = set(rhs)
-
-        # Look for deleted keys
-        for key in lhs_keys - rhs_keys:
-            next_path = YAMLPath(path).append(key)
-            self._diffs.append(
-                DiffEntry(
-                    DiffActions.DELETE, next_path, lhs[key], None,
-                    lhs_parent=lhs, rhs_parent=rhs))
-
-        # Look for new keys
-        for key in rhs_keys - lhs_keys:
-            next_path = YAMLPath(path).append(key)
-            self._diffs.append(
-                DiffEntry(
-                    DiffActions.ADD, next_path, None, rhs[key],
-                    lhs_parent=lhs, rhs_parent=rhs))
-
-        # Recurse into the rest
-        for key, val in [
-            (key, val) for key, val in rhs.items()
-            if key in lhs and key in rhs
-        ]:
-            next_path = YAMLPath(path).append(key)
-            self._diff_between(
-                next_path, lhs[key], val, lhs_parent=lhs, rhs_parent=rhs)
-
-    def _diff_lists(self, path: YAMLPath, lhs: list, rhs: list) -> None:
-        """Diff two lists."""
-        if self._sync_arrays:
-            self._diff_synced_lists(path, lhs, rhs)
-            return
-
-        idx = 0
-        for (lele, rele) in zip_longest(lhs, rhs):
-            next_path = YAMLPath(path).append("[{}]".format(idx))
-            idx += 1
-            if lele is None:
-                self._diffs.append(
-                    DiffEntry(
-                        DiffActions.ADD, next_path, None, rele,
-                        lhs_parent=lhs, rhs_parent=rhs))
-            elif rele is None:
-                self._diffs.append(
-                    DiffEntry(
-                        DiffActions.DELETE, next_path, lele, None,
-                        lhs_parent=lhs, rhs_parent=rhs))
-            else:
-                self._diff_between(
-                    next_path, lele, rele, lhs_parent=lhs, rhs_parent=rhs)
-
-    def _diff_synced_lists(self, path: YAMLPath, lhs: list, rhs: list) -> None:
-        """Diff two synchronized lists."""
-        # lhs = [1, 2, 2, 3]
-        # rhs = [2, 3, 3, 4]
-        # syn = [[1, None], [2, 2], [2, None], [3, 3], [None, 3], [None, 4]]
-        # lsy = [1,    2, 2,    3, None, None]
-        # rsy = [None, 2, None, 3, 3,    4]
-        debug_path = path if path else "/"
-        self.logger.debug(
-            "Synchronizing LHS Array elements at YAML Path, {}:"
-            .format(debug_path),
-            prefix="Differ::_diff_syncd_lists:  ",
-            data=lhs)
-        self.logger.debug(
-            "Synchronizing RHS Array elements at YAML Path, {}:"
-            .format(debug_path),
-            prefix="Differ::_diff_syncd_lists:  ",
-            data=rhs)
-
-        rhs_reduced = rhs.copy()
-        syn_pairs = []
-        for lhs_ele in lhs:
-            del_index = -1
-            for idx, ele in enumerate(rhs_reduced):
-                if ele == lhs_ele:
-                    del_index = idx
-                    break
-            if del_index > -1:
-                rhs_ele = rhs_reduced.pop(del_index)
-                syn_pairs.append((lhs_ele, rhs_ele))
-            else:
-                syn_pairs.append((lhs_ele, None))
-        for rhs_ele in rhs_reduced:
-            syn_pairs.append((None, rhs_ele))
-
-        self.logger.debug(
-            "Got synchronized pairs of Array elements at YAML Path, {}:"
-            .format(debug_path),
-            prefix="Differ::_diff_syncd_lists:  ",
-            data=syn_pairs)
-
-        idx = 0
-        for (lele, rele) in syn_pairs:
-            next_path = YAMLPath(path).append("[{}]".format(idx))
-            idx += 1
-            if lele is None:
-                self._diffs.append(
-                    DiffEntry(
-                        DiffActions.ADD, next_path, None, rele,
-                        lhs_parent=lhs, rhs_parent=rhs))
-            elif rele is None:
-                self._diffs.append(
-                    DiffEntry(
-                        DiffActions.DELETE, next_path, lele, None,
-                        lhs_parent=lhs, rhs_parent=rhs))
-            else:
-                self._diff_between(
-                    next_path, lele, rele, lhs_parent=lhs, rhs_parent=rhs)
-
     def _diff_scalars(
         self, path: YAMLPath, lhs: Any, rhs: Any, **kwargs
     ) -> None:
         """Diff two Scalar values."""
+        self.logger.debug(
+            "Comparing LHS:",
+            prefix="Differ::_diff_scalars:  ",
+            data=lhs)
+        self.logger.debug(
+            "Against RHS:",
+            prefix="Differ::_diff_scalars:  ",
+            data=rhs)
+
         lhs_val = lhs
         rhs_val = rhs
         if (not self._ignore_eyaml
@@ -260,3 +137,409 @@ class Differ:
             self._diffs.append(
                 DiffEntry(DiffActions.CHANGE, path, lhs, rhs, **kwargs)
             )
+
+    def _diff_dicts(self, path: YAMLPath, lhs: dict, rhs: dict) -> None:
+        """Diff two dicts."""
+        self.logger.debug(
+            "Comparing LHS:",
+            prefix="Differ::_diff_dicts:  ",
+            data=lhs)
+        self.logger.debug(
+            "Against RHS:",
+            prefix="Differ::_diff_dicts:  ",
+            data=rhs)
+
+        lhs_keys = set(lhs)
+        rhs_keys = set(rhs)
+        lhs_key_indicies = Differ._get_key_indicies(lhs)
+        rhs_key_indicies = Differ._get_key_indicies(rhs)
+
+        self.logger.debug(
+            "Got LHS key indicies:",
+            prefix="Differ::_diff_dicts:  ",
+            data=lhs_key_indicies)
+        self.logger.debug(
+            "Got RHS key indicies:",
+            prefix="Differ::_diff_dicts:  ",
+            data=rhs_key_indicies)
+
+        # Look for changes
+        for key, val in [
+            (key, val) for key, val in rhs.items()
+            if key in lhs and key in rhs
+        ]:
+            next_path = YAMLPath(path).append(key)
+            self._diff_between(
+                next_path, lhs[key], val,
+                lhs_parent=lhs, lhs_iteration=lhs_key_indicies[key],
+                rhs_parent=rhs, rhs_iteration=rhs_key_indicies[key],
+                parentref=key)
+
+        # Look for deleted keys
+        for key in lhs_keys - rhs_keys:
+            next_path = YAMLPath(path).append(key)
+            self._diffs.append(
+                DiffEntry(
+                    DiffActions.DELETE, next_path, lhs[key], None,
+                    lhs_parent=lhs, lhs_iteration=lhs_key_indicies[key],
+                    rhs_parent=rhs))
+
+        # Look for new keys
+        for key in rhs_keys - lhs_keys:
+            next_path = YAMLPath(path).append(key)
+            self._diffs.append(
+                DiffEntry(
+                    DiffActions.ADD, next_path, None, rhs[key],
+                    lhs_parent=lhs,
+                    rhs_parent=rhs, rhs_iteration=rhs_key_indicies[key]))
+
+    def _diff_synced_lists(self, path: YAMLPath, lhs: list, rhs: list) -> None:
+        """Diff two synchronized lists."""
+        self.logger.debug("Differ::_diff_synced_lists:  Starting...")
+        self.logger.debug(
+            "Synchronizing LHS Array elements at YAML Path, {}:"
+            .format(path if path else "/"),
+            prefix="Differ::_diff_syncd_lists:  ",
+            data=lhs)
+        self.logger.debug(
+            "Synchronizing RHS Array elements at YAML Path, {}:"
+            .format(path if path else "/"),
+            prefix="Differ::_diff_syncd_lists:  ",
+            data=rhs)
+
+        syn_pairs = Differ.synchronize_lists_by_value(lhs, rhs)
+        self.logger.debug(
+            "Got synchronized pairs of Array elements at YAML Path, {}:"
+            .format(path if path else "/"),
+            prefix="Differ::_diff_syncd_lists:  ",
+            data=syn_pairs)
+
+        for (lidx, lele, ridx, rele) in syn_pairs:
+            if lele is None:
+                next_path = YAMLPath(path).append("[{}]".format(ridx))
+                diff_action = DiffActions.ADD
+                opposite_val = None
+                pop_index = -1
+                for idx, ele in reversed(list(enumerate(self._diffs))):
+                    if (ele.action is DiffActions.DELETE
+                        and ele.path == next_path
+                    ):
+                        pop_index = idx
+                        break
+
+                # This YAML Path has ALREADY been recorded as a DELETE.  Since
+                # a DELETE->ADD action is really just a CHANGE, remove the
+                # conflicting entry and convert this pending ADD to a CHANGE.
+                if pop_index > -1:
+                    opposite_val = self._diffs.pop(pop_index).lhs
+                    diff_action = DiffActions.CHANGE
+
+                self._diffs.append(DiffEntry(
+                    diff_action, next_path, opposite_val, rele,
+                    lhs_parent=lhs, lhs_iteration=lidx,
+                    rhs_parent=rhs, rhs_iteration=ridx))
+            elif rele is None:
+                next_path = YAMLPath(path).append("[{}]".format(lidx))
+                self._diffs.append(
+                    DiffEntry(
+                        DiffActions.DELETE, next_path, lele, None,
+                        lhs_parent=lhs, lhs_iteration=lidx,
+                        rhs_parent=rhs, rhs_iteration=ridx))
+            else:
+                next_path = YAMLPath(path).append("[{}]".format(lidx))
+                self._diff_between(
+                    next_path, lele, rele,
+                    lhs_parent=lhs, lhs_iteration=lidx,
+                    rhs_parent=rhs, rhs_iteration=ridx,
+                    parentref=ridx)
+
+    def _diff_arrays_of_scalars(
+        self, path: YAMLPath, lhs: list, rhs: list, node_coord: NodeCoords,
+        **kwargs
+    ) -> None:
+        """Diff two lists of scalars."""
+        self.logger.debug(
+            "Comparing LHS:",
+            prefix="Differ::_diff_arrays_of_scalars:  ",
+            data=lhs)
+        self.logger.debug(
+            "Against RHS:",
+            prefix="Differ::_diff_arrays_of_scalars:  ",
+            data=rhs)
+
+        diff_mode = self.config.array_diff_mode(node_coord)
+        if diff_mode is ArrayDiffOpts.VALUE:
+            self._diff_synced_lists(path, lhs, rhs)
+            return
+
+        idx = 0
+        diff_deeply = kwargs.pop("diff_deeply", True)
+        for (lele, rele) in zip_longest(lhs, rhs):
+            next_path = YAMLPath(path).append("[{}]".format(idx))
+            idx += 1
+            if lele is None:
+                self._diffs.append(
+                    DiffEntry(
+                        DiffActions.ADD, next_path, None, rele,
+                        lhs_parent=lhs, lhs_iteration=idx,
+                        rhs_parent=rhs, rhs_iteration=idx))
+            elif rele is None:
+                self._diffs.append(
+                    DiffEntry(
+                        DiffActions.DELETE, next_path, lele, None,
+                        lhs_parent=lhs, lhs_iteration=idx,
+                        rhs_parent=rhs, rhs_iteration=idx))
+            elif diff_deeply:
+                self._diff_between(
+                    next_path, lele, rele,
+                    lhs_parent=lhs, lhs_iteration=idx,
+                    rhs_parent=rhs, rhs_iteration=idx,
+                    parentref=idx)
+            elif lele != rele:
+                self._diffs.append(
+                    DiffEntry(
+                        DiffActions.CHANGE, next_path, lele, rele,
+                        lhs_parent=lhs, lhs_iteration=idx,
+                        rhs_parent=rhs, rhs_iteration=idx,
+                        parentref=idx))
+
+    def _diff_arrays_of_hashes(
+        self, path: YAMLPath, lhs: list, rhs: list, node_coord: NodeCoords
+    ) -> None:
+        """Diff two lists-of-dictionaries."""
+        self.logger.debug(
+            "Comparing LHS:",
+            prefix="Differ::_diff_arrays_of_hashes:  ",
+            data=lhs)
+        self.logger.debug(
+            "Against RHS:",
+            prefix="Differ::_diff_arrays_of_hashes:  ",
+            data=rhs)
+
+        diff_mode = self.config.aoh_diff_mode(node_coord)
+        if diff_mode is AoHDiffOpts.POSITION:
+            self._diff_arrays_of_scalars(
+                path, lhs, rhs, node_coord, diff_deeply=False)
+            return
+        if diff_mode is AoHDiffOpts.DPOS:
+            self._diff_arrays_of_scalars(
+                path, lhs, rhs, node_coord, diff_deeply=True)
+            return
+        if diff_mode is AoHDiffOpts.VALUE:
+            self._diff_synced_lists(path, lhs, rhs)
+            return
+        deep_diff = diff_mode is AoHDiffOpts.DEEP
+
+        self.logger.debug(
+            "Synchronizing LHS Array elements at YAML Path, {}:"
+            .format(path if path else "/"),
+            prefix="Differ::_diff_arrays_of_hashes:  ",
+            data=lhs)
+        self.logger.debug(
+            "Synchronizing RHS Array elements at YAML Path, {}:"
+            .format(path if path else "/"),
+            prefix="Differ::_diff_arrays_of_hashes:  ",
+            data=rhs)
+
+        # Perform either a KEY or DEEP comparison; either way, the elements
+        # must first be synchronized based on their identity key values.
+        id_key: str = ""
+        if len(rhs) > 0 and isinstance(rhs[0], dict):
+            id_key = self.config.aoh_diff_key(
+                NodeCoords(rhs[0], rhs, 0), rhs[0])
+            self.logger.debug(
+                "Differ::_diff_arrays_of_hashes:  RHS AoH yielded id_key:"
+                "  {}.".format(id_key))
+
+        syn_pairs = Differ.synchronize_lods_by_key(lhs, rhs, id_key)
+        self.logger.debug(
+            "Got synchronized pairs of Array elements at YAML Path, {}:"
+            .format(path if path else "/"),
+            prefix="Differ::_diff_arrays_of_hashes:  ",
+            data=syn_pairs)
+
+        for (lidx, lele, ridx, rele) in syn_pairs:
+            if lele is None:
+                next_path = YAMLPath(path).append("[{}]".format(ridx))
+                self._diffs.append(
+                    DiffEntry(
+                        DiffActions.ADD, next_path, None, rele,
+                        lhs_parent=lhs, lhs_iteration=lidx,
+                        rhs_parent=rhs, rhs_iteration=ridx))
+            elif rele is None:
+                next_path = YAMLPath(path).append("[{}]".format(lidx))
+                self._diffs.append(
+                    DiffEntry(
+                        DiffActions.DELETE, next_path, lele, None,
+                        lhs_parent=lhs, lhs_iteration=lidx,
+                        rhs_parent=rhs, rhs_iteration=ridx))
+            else:
+                if deep_diff:
+                    next_path = YAMLPath(path).append("[{}]".format(ridx))
+                    self._diff_between(
+                        next_path, lele, rele,
+                        lhs_parent=lhs, lhs_iteration=lidx,
+                        rhs_parent=rhs, rhs_iteration=ridx,
+                        parentref=ridx)
+                else:
+                    # KEY-based comparisons
+                    next_path = YAMLPath(path).append("[{}]".format(lidx))
+                    diff_action = (DiffActions.SAME
+                                  if lele == rele
+                                  else DiffActions.CHANGE)
+                    self._diffs.append(
+                        DiffEntry(diff_action, next_path, lele, rele,
+                        lhs_parent=lhs, lhs_iteration=lidx,
+                        rhs_parent=rhs, rhs_iteration=ridx,
+                        parentref=lidx))
+
+    def _diff_lists(
+        self, path: YAMLPath, lhs: list, rhs: list, **kwargs
+    ) -> None:
+        """Diff two lists."""
+        self.logger.debug(
+            "Comparing LHS:",
+            prefix="Differ::_diff_lists:  ",
+            data=lhs)
+        self.logger.debug(
+            "Against RHS:",
+            prefix="Differ::_diff_lists:  ",
+            data=rhs)
+
+        parent: Any = kwargs.pop("rhs_parent", None)
+        parentref: Any = kwargs.pop("parentref", None)
+        node_coord = NodeCoords(rhs, parent, parentref)
+        if len(rhs) > 0:
+            if isinstance(rhs[0], dict):
+                # This list is an Array-of-Hashes
+                self._diff_arrays_of_hashes(path, lhs, rhs, node_coord)
+            else:
+                # This list is an Array-of-Arrays or a simple list of Scalars
+                self._diff_arrays_of_scalars(path, lhs, rhs, node_coord)
+
+    def _diff_between(
+        self, path: YAMLPath, lhs: Any, rhs: Any, **kwargs
+    ) -> None:
+        """Calculate the differences between two document nodes."""
+        self.logger.debug(
+            "Comparing LHS:",
+            prefix="Differ::_diff_between:  ",
+            data=lhs)
+        self.logger.debug(
+            "Against RHS:",
+            prefix="Differ::_diff_between:  ",
+            data=rhs)
+
+        # If the roots are different, delete all LHS and add all RHS.
+        lhs_is_dict = isinstance(lhs, dict)
+        lhs_is_list = isinstance(lhs, list)
+        lhs_is_scalar = not (lhs_is_dict or lhs_is_list)
+        rhs_is_dict = isinstance(rhs, dict)
+        rhs_is_list = isinstance(rhs, list)
+        rhs_is_scalar = not (rhs_is_dict or rhs_is_list)
+        same_types = (
+            (lhs_is_dict and rhs_is_dict)
+            or (lhs_is_list and rhs_is_list)
+            or (lhs_is_scalar and rhs_is_scalar)
+        )
+        if same_types:
+            if lhs_is_dict:
+                self._diff_dicts(path, lhs, rhs)
+            elif lhs_is_list:
+                self._diff_lists(path, lhs, rhs, **kwargs)
+            else:
+                self._diff_scalars(path, lhs, rhs, **kwargs)
+        else:
+            self._purge_document(path, lhs)
+            self._add_everything(path, rhs)
+
+    @classmethod
+    def synchronize_lists_by_value(
+        cls, lhs: list, rhs: list
+    ) -> List[Tuple[
+        Optional[int], Optional[Any], Optional[int], Optional[Any]
+    ]]:
+        """Synchronize two lists by value."""
+        # Build a parallel index array to track the original RHS element
+        # indexes of any surviving elements.
+        rhs_reduced = []
+        for original_idx, val in enumerate(rhs):
+            rhs_reduced.append((original_idx, val))
+
+        syn_pairs: List[Tuple[
+            Optional[int], Optional[Any], Optional[int], Optional[Any]
+        ]] = []
+        for lhs_idx, lhs_ele in enumerate(lhs):
+            del_index = -1
+            for reduced_idx, rhs_pair in enumerate(rhs_reduced):
+                (_, rhs_ele) = rhs_pair
+                if rhs_ele == lhs_ele:
+                    del_index = reduced_idx
+                    break
+
+            if del_index > -1:
+                (rhs_original_idx, rhs_ele) = rhs_reduced.pop(del_index)
+                syn_pairs.append((lhs_idx, lhs_ele, rhs_original_idx, rhs_ele))
+            else:
+                syn_pairs.append((lhs_idx, lhs_ele, None, None))
+
+        for rhs_pair in rhs_reduced:
+            (rhs_original_idx, rhs_ele) = rhs_pair
+            syn_pairs.append((None, None, rhs_original_idx, rhs_ele))
+
+        return syn_pairs
+
+    @classmethod
+    #pylint: disable=too-many-locals
+    def synchronize_lods_by_key(
+        cls, lhs: list, rhs: list, key_attr: str
+    ) -> List[Tuple[
+        Optional[int], Optional[Any], Optional[int], Optional[Any]
+    ]]:
+        """Synchronize two lists-of-dictionaries by identity key."""
+        # Build a parallel index array to track the original RHS element
+        # indexes of any surviving elements.
+        rhs_reduced = []
+        for original_idx, val in enumerate(rhs):
+            rhs_reduced.append((original_idx, val))
+
+        syn_pairs: List[Tuple[
+            Optional[int], Optional[Any], Optional[int], Optional[Any]
+        ]] = []
+        for lhs_idx, lhs_ele in enumerate(lhs):
+            if not key_attr in lhs_ele:
+                # Impossible to match this LHS record to any RHS record
+                syn_pairs.append((lhs_idx, lhs_ele, None, None))
+                continue
+
+            del_index = -1
+            for reduced_idx, rhs_pair in enumerate(rhs_reduced):
+                (_, rhs_ele) = rhs_pair
+                if not key_attr in rhs_ele:
+                    # Impossible to match this RHS record to any LHS record
+                    continue
+
+                if rhs_ele[key_attr] == lhs_ele[key_attr]:
+                    del_index = reduced_idx
+                    break
+
+            if del_index > -1:
+                (rhs_original_idx, rhs_ele) = rhs_reduced.pop(del_index)
+                syn_pairs.append((lhs_idx, lhs_ele, rhs_original_idx, rhs_ele))
+            else:
+                syn_pairs.append((lhs_idx, lhs_ele, None, None))
+
+        for rhs_pair in rhs_reduced:
+            (rhs_original_idx, rhs_ele) = rhs_pair
+            syn_pairs.append((None, None, rhs_original_idx, rhs_ele))
+
+        return syn_pairs
+
+    @classmethod
+    def _get_key_indicies(cls, data: dict) -> Dict[Any, int]:
+        """Get a dictionary mapping of keys to relative positions."""
+        key_map = {}
+        if isinstance(data, dict):
+            for idx, key in enumerate(data.keys()):
+                key_map[key] = idx
+        return key_map

--- a/yamlpath/differ/differconfig.py
+++ b/yamlpath/differ/differconfig.py
@@ -1,0 +1,262 @@
+"""
+Config file processor for the Differ.
+
+Copyright 2020 William W. Kimball, Jr. MBA MSIS
+"""
+import configparser
+from typing import Any, Dict, Union
+from argparse import Namespace
+
+from yamlpath.exceptions import YAMLPathException
+from yamlpath.differ.enums import AoHDiffOpts, ArrayDiffOpts
+from yamlpath import Processor, YAMLPath
+from yamlpath.wrappers import ConsolePrinter, NodeCoords
+
+
+class DifferConfig:
+    """Config file processor for the Differ."""
+
+    def __init__(self, logger: ConsolePrinter, args: Namespace) -> None:
+        """
+        Instantiate this class into an object.
+
+        Parameters:
+        1. logger (ConsolePrinter) Instance of ConsoleWriter or subclass
+        2. args (dict) Default options for diff rules
+
+        Returns:  N/A
+        """
+        self.log = logger
+        self.args = args
+        self.config: Union[None, configparser.ConfigParser] = None
+        self.rules: Dict[NodeCoords, str] = {}
+        self.keys: Dict[NodeCoords, str] = {}
+
+        self._load_config()
+
+    def array_diff_mode(self, node_coord: NodeCoords) -> ArrayDiffOpts:
+        """
+        Get Array diff mode applicable to the indicated path.
+
+        Parameters:
+        1. node_coord (NodeCoords) The node for which to query.
+
+        Returns:  (ArrayDiffOpts) Applicable mode.
+        """
+        # Precedence: config[rules] > CLI > config[defaults] > default
+        diff_rule = self._get_rule_for(node_coord)
+        if diff_rule:
+            self.log.debug(
+                "DifferConfig::array_diff_mode:  Matched {}"
+                .format(diff_rule))
+            return ArrayDiffOpts.from_str(diff_rule)
+        self.log.debug("DifferConfig::array_diff_mode:  NOT Matched")
+        if hasattr(self.args, "arrays") and self.args.arrays:
+            return ArrayDiffOpts.from_str(self.args.arrays)
+        if (self.config is not None
+                and "defaults" in self.config
+                and "arrays" in self.config["defaults"]):
+            return ArrayDiffOpts.from_str(self.config["defaults"]["arrays"])
+        return ArrayDiffOpts.POSITION
+
+    def aoh_diff_mode(self, node_coord: NodeCoords) -> AoHDiffOpts:
+        """
+        Get Array-of-Hashes diff mode applicable to the indicated path.
+
+        Parameters:
+        1. node_coord (NodeCoords) The node for which to query.
+
+        Returns:  (AoHDiffOpts) Applicable mode.
+        """
+        # Precedence: config[rules] > CLI > config[defaults] > default
+        diff_rule = self._get_rule_for(node_coord)
+        if diff_rule:
+            self.log.debug(
+                "DifferConfig::aoh_diff_mode:  Matched {}"
+                .format(diff_rule))
+            return AoHDiffOpts.from_str(diff_rule)
+        self.log.debug("DifferConfig::aoh_diff_mode:  NOT Matched")
+        if hasattr(self.args, "aoh") and self.args.aoh:
+            return AoHDiffOpts.from_str(self.args.aoh)
+        if (self.config is not None
+                and "defaults" in self.config
+                and "aoh" in self.config["defaults"]):
+            return AoHDiffOpts.from_str(self.config["defaults"]["aoh"])
+        return AoHDiffOpts.POSITION
+
+    def aoh_diff_key(
+        self, node_coord: NodeCoords, data: dict
+    ) -> str:
+        """
+        Get the user-defined identity key for Array-of-Hashes comparisons.
+
+        Parameters:
+        1. node_coord (NodeCoords) The node for which to query.
+        2. data (dict) The diff source node from which an identity key will
+           be inferred if not explicity provided via user configuration.
+
+        Returns: (str) The identity key field name.
+        """
+        # Check the user config for a specific key; fallback to first key.
+        diff_key = self._get_key_for(node_coord)
+        if not diff_key:
+            # This node may be a child of one of the registered keys.  That
+            # registered key's node will match this node's parent.
+            for eval_nc, eval_key in self.keys.items():
+                if node_coord.parent == eval_nc.node:
+                    diff_key = eval_key
+                    break
+        if not diff_key and len(data.keys()) > 0:
+            # Fallback to using the first key of the dict as an identity key
+            diff_key = list(data)[0]
+        return diff_key
+
+    def prepare(self, data: Any) -> None:
+        """
+        Load references to all nodes which match config rules.
+
+        Parameters:
+        1. data (Any) The DOM for which to load configuration.
+
+        Returns:  N/A
+        """
+        if self.config is None:
+            return
+
+        # Eliminate previous rules and keys to limit scanning to only those
+        # nodes which exist within this new document.
+        self.rules = {}
+        self.keys = {}
+
+        # Load new rules and keys
+        proc = Processor(self.log, data)
+        self._prepare_user_rules(proc, "rules", self.rules)
+        self._prepare_user_rules(proc, "keys", self.keys)
+
+    def _prepare_user_rules(
+        self, proc: Processor, section: str, collector: dict
+    ) -> None:
+        """
+        Identify DOM nodes matching user-defined diff rules.
+
+        Parameters:
+        1. proc (Processor) Reference to the DOM Processor.
+        2. section (str) User-configuration file section defining the diff
+           rules to apply.
+        3. collector (dict) Storage collector for matching nodes.
+
+        Returns:  N/A
+        """
+        if self.config is None or not section in self.config:
+            self.log.warning(
+                "User-specified configuration file has no {} section."
+                .format(section))
+            return
+
+        for rule_key in self.config[section]:
+            rule_value = self.config[section][rule_key]
+
+            if "=" in rule_value:
+                # There were at least two = signs on the configuration line
+                conf_line = rule_key + "=" + rule_value
+                delim_pos = conf_line.rfind("=")
+                rule_key = conf_line[0:delim_pos].strip()
+                rule_value = conf_line[delim_pos + 1:].strip()
+                self.log.debug(
+                    "DifferConfig::_prepare_user_rules:  Reconstituted"
+                    " configuration line '{}' to extract adjusted key '{}'"
+                    " with value '{}'".format(conf_line, rule_key, rule_value))
+
+            rule_path = YAMLPath(rule_key)
+            yaml_path = YAMLPath(rule_path)
+            self.log.debug(
+                "DifferConfig::_prepare_user_rules:  Matching '{}' nodes to"
+                " YAML Path '{}' from key, {}."
+                .format(section, yaml_path, rule_key))
+            try:
+                for node_coord in proc.get_nodes(yaml_path, mustexist=True):
+                    self.log.debug(
+                        "Node will have comparisons rule, {}:"
+                        .format(rule_value),
+                        prefix="DifferConfig::_prepare_user_rules:  ",
+                        data=node_coord.node)
+                    collector[node_coord] = rule_value
+
+            except YAMLPathException:
+                self.log.warning("{} YAML Path matches no nodes:  {}"
+                                .format(section, yaml_path))
+
+        self.log.debug(
+            "Matched rules to nodes:",
+            prefix="DifferConfig::_prepare_user_rules:  ")
+        for node_coord, diff_rule in collector.items():
+            self.log.debug(
+                "... RULE:  {}".format(diff_rule),
+                prefix="DifferConfig::_prepare_user_rules:  ")
+            self.log.debug(
+                "... NODE:", data=node_coord,
+                prefix="DifferConfig::_prepare_user_rules:  ")
+
+    def _load_config(self) -> None:
+        """Load the external configuration file."""
+        config = configparser.ConfigParser()
+
+        # Load the configuration file when one is specified
+        config_file = (
+            self.args.config
+            if hasattr(self.args, "config")
+            else None)
+
+        if config_file:
+            config.read(config_file)
+            if config.sections():
+                self.config = config
+
+    def _get_config_for(self, node_coord: NodeCoords, section: dict) -> str:
+        """
+        Get user configuration applicable to a node.
+
+        Parameters:
+        1. node_coord (NodeCoords) The node for which to retrieve config.
+        2. section (dict) The configuration section to query.
+
+        Returns: (str) The requested configuration.
+        """
+        if self.config is None:
+            return ""
+
+        for rule_coord, rule_config in section.items():
+            if rule_coord.node == node_coord.node \
+                    and rule_coord.parent == node_coord.parent \
+                    and rule_coord.parentref == node_coord.parentref:
+                return str(rule_config)
+
+        return ""
+
+    def _get_rule_for(self, node_coord: NodeCoords) -> str:
+        """
+        Get a user configured diff rule for a node.
+
+        Parameters:
+        1. node_coord (NodeCoords) The node for which to retrieve config.
+
+        Returns: (str) The requested configuration.
+        """
+        self.log.debug(
+            "Seeking rule for node:", prefix="DifferConfig::_get_rule_for:  ",
+            header=" ")
+        self.log.debug(
+            "... NODE:", prefix="DifferConfig::_get_rule_for:  ",
+            data=node_coord)
+        return self._get_config_for(node_coord, self.rules)
+
+    def _get_key_for(self, node_coord: NodeCoords) -> str:
+        """
+        Get a user configured diff identity key (field) for a node.
+
+        Parameters:
+        1. node_coord (NodeCoords) The node for which to retrieve config.
+
+        Returns: (str) The requested configuration.
+        """
+        return self._get_config_for(node_coord, self.keys)

--- a/yamlpath/differ/enums/__init__.py
+++ b/yamlpath/differ/enums/__init__.py
@@ -1,2 +1,4 @@
 """Differ enumerations."""
+from .aohdiffopts import AoHDiffOpts
+from .arraydiffopts import ArrayDiffOpts
 from .diffactions import DiffActions

--- a/yamlpath/differ/enums/__init__.py
+++ b/yamlpath/differ/enums/__init__.py
@@ -1,0 +1,2 @@
+"""Differ enumerations."""
+from .diffactions import DiffActions

--- a/yamlpath/differ/enums/aohdiffopts.py
+++ b/yamlpath/differ/enums/aohdiffopts.py
@@ -1,0 +1,105 @@
+"""
+Implements the AoHDiffOpts enumeration.
+
+Copyright 2020 William W. Kimball, Jr. MBA MSIS
+"""
+from enum import Enum, auto
+from typing import List
+
+
+class AoHDiffOpts(Enum):
+    """
+    Supported Array-of-Hash (AKA: List-of-Dictionaries) Diff Options.
+
+    Options include:
+
+    `DEEP`
+        Like KEY except the record pairs are deeply traversed, looking for
+        specific internal differences, after being matched up.
+
+    `DPOS`
+        Like POSITION (no KEY matching) except the record pairs are deeply
+        traversed to report every specific difference between them.
+
+    `KEY`
+        AoH records are synchronized by their identity key before being
+        compared as whole units (no deep traversal).
+
+    `POSITION`
+        AoH records are compared as whole units (no deep traversal) based on
+        their ordinal position in each document.
+
+    `VALUE`
+        AoH records are synchronized as whole units (no deep traversal) before
+        being compared.
+    """
+
+    DEEP = auto()
+    DPOS = auto()
+    KEY = auto()
+    POSITION = auto()
+    VALUE = auto()
+
+    def __str__(self) -> str:
+        """
+        Stringify one instance of this enumeration.
+
+        Parameters:  N/A
+
+        Returns:  (str) String value of this enumeration.
+
+        Raises:  N/A
+        """
+        return str(self.name).lower()
+
+    @staticmethod
+    def get_names() -> List[str]:
+        """
+        Get all upper-cased entry names for this enumeration.
+
+        Parameters:  N/A
+
+        Returns:  (List[str]) Upper-case names from this enumeration
+
+        Raises:  N/A
+        """
+        return [entry.name.upper() for entry in AoHDiffOpts]
+
+    @staticmethod
+    def get_choices() -> List[str]:
+        """
+        Get all entry names with symbolic representations for this enumeration.
+
+        All returned entries are lower-cased.
+
+        Parameters:  N/A
+
+        Returns:  (List[str]) Lower-case names and symbols from this
+            enumeration
+
+        Raises:  N/A
+        """
+        names = [l.lower() for l in AoHDiffOpts.get_names()]
+        choices = list(set(names))
+        choices.sort()
+        return choices
+
+    @staticmethod
+    def from_str(name: str) -> "AoHDiffOpts":
+        """
+        Convert a string value to a value of this enumeration, if valid.
+
+        Parameters:
+            1. name (str) The name to convert
+
+        Returns:  (AoHDiffOpts) the converted enumeration value
+
+        Raises:
+            - `NameError` when name doesn't match any enumeration values
+        """
+        check: str = str(name).upper()
+        if check in AoHDiffOpts.get_names():
+            return AoHDiffOpts[check]
+        raise NameError(
+            "AoHDiffOpts has no such item:  {}"
+            .format(name))

--- a/yamlpath/differ/enums/arraydiffopts.py
+++ b/yamlpath/differ/enums/arraydiffopts.py
@@ -1,0 +1,89 @@
+"""
+Implements the ArrayDiffOpts enumeration.
+
+Copyright 2020 William W. Kimball, Jr. MBA MSIS
+"""
+from enum import Enum, auto
+from typing import List
+
+
+class ArrayDiffOpts(Enum):
+    """
+    Supported Array (AKA: List) Diff Options.
+
+    Options include:
+
+    `POSITION`
+        Array elements are compared based on their ordinal position in each
+        document.
+
+    `VALUE`
+        Array alements are synchronized by value before being compared.
+    """
+
+    POSITION = auto()
+    VALUE = auto()
+
+    def __str__(self) -> str:
+        """
+        Stringify one instance of this enumeration.
+
+        Parameters:  N/A
+
+        Returns:  (str) String value of this enumeration.
+
+        Raises:  N/A
+        """
+        return str(self.name).lower()
+
+    @staticmethod
+    def get_names() -> List[str]:
+        """
+        Get all upper-cased entry names for this enumeration.
+
+        Parameters:  N/A
+
+        Returns:  (List[str]) Upper-case names from this enumeration
+
+        Raises:  N/A
+        """
+        return [entry.name.upper() for entry in ArrayDiffOpts]
+
+    @staticmethod
+    def get_choices() -> List[str]:
+        """
+        Get all entry names with symbolic representations for this enumeration.
+
+        All returned entries are lower-cased.
+
+        Parameters:  N/A
+
+        Returns:  (List[str]) Lower-case names and symbols from this
+            enumeration
+
+        Raises:  N/A
+        """
+        names = [l.lower() for l in ArrayDiffOpts.get_names()]
+        choices = list(set(names))
+        choices.sort()
+        return choices
+
+    @staticmethod
+    def from_str(name: str) -> "ArrayDiffOpts":
+        """
+        Convert a string value to a value of this enumeration, if valid.
+
+        Parameters:
+            1. name (str) The name to convert
+
+        Returns:  (ArrayDiffOpts) the converted enumeration value
+
+        Raises:
+            - `NameError` when name doesn't match any enumeration values
+        """
+        check: str = str(name).upper()
+        if check in ArrayDiffOpts.get_names():
+            return ArrayDiffOpts[check]
+        raise NameError(
+            "ArrayDiffOpts has no such item:  {}"
+            .format(name))

--- a/yamlpath/differ/enums/diffactions.py
+++ b/yamlpath/differ/enums/diffactions.py
@@ -1,0 +1,42 @@
+"""
+Implements the DiffActions enumeration.
+
+Copyright 2019, 2020 William W. Kimball, Jr. MBA MSIS
+"""
+from enum import Enum, auto
+
+
+class DiffActions(Enum):
+    """
+    The action taken for one document to become the next.
+
+    `ADD`
+        Add an entry
+
+    `CHANGE`
+        An entry has changed.
+
+    `DELETE`
+        Remove an entry.
+
+    `SAME`
+        The two entries are identical.
+    """
+
+    ADD = auto()
+    CHANGE = auto()
+    DELETE = auto()
+    SAME = auto()
+
+    def __str__(self) -> str:
+        """Get the diff-like entry code for this action."""
+        diff_type = ""
+        if self is DiffActions.ADD:
+            diff_type = "a"
+        elif self is DiffActions.CHANGE:
+            diff_type = "c"
+        elif self is DiffActions.DELETE:
+            diff_type = "d"
+        else:
+            diff_type = "s"
+        return diff_type

--- a/yamlpath/merger/merger.py
+++ b/yamlpath/merger/merger.py
@@ -14,6 +14,7 @@ from ruamel.yaml.comments import CommentedSeq, CommentedMap
 
 from yamlpath.func import (
     append_list_element,
+    escape_path_section,
     build_next_node,
     stringify_dates,
 )
@@ -137,7 +138,7 @@ class Merger:
         buffer: List[Tuple[Any, Any]] = []
         buffer_pos = 0
         for key, val in rhs.non_merged_items():
-            path_next = YAMLPath(path).append(str(key))
+            path_next = path + escape_path_section(key, path.seperator)
             if key in lhs:
                 # Write the buffer if populated
                 for b_key, b_val in buffer:
@@ -260,7 +261,7 @@ class Merger:
 
         append_all = merge_mode is ArrayMergeOpts.ALL
         for idx, ele in enumerate(rhs):
-            path_next = YAMLPath(path).append("[{}]".format(idx))
+            path_next = path + "[{}]".format(idx)
             self.logger.debug(
                 "Processing element {} at {}.".format(idx, path_next),
                 prefix="Merger::_merge_simple_lists:  ", data=ele)
@@ -316,7 +317,7 @@ class Merger:
 
         merge_mode = self.config.aoh_merge_mode(node_coord)
         for idx, ele in enumerate(rhs):
-            path_next = YAMLPath(path).append("[{}]".format(idx))
+            path_next = path + "[{}]".format(idx)
             self.logger.debug(
                 "Processing element #{} at {}.".format(idx, path_next),
                 prefix="Merger::_merge_arrays_of_hashes:  ", data=ele)

--- a/yamlpath/wrappers/consoleprinter.py
+++ b/yamlpath/wrappers/consoleprinter.py
@@ -253,9 +253,13 @@ class ConsolePrinter:
     ) -> Generator[str, None, None]:
         """Helper method for debug."""
         prefix = kwargs.pop("prefix", "")
+        path_prefix = "{}(path)".format(prefix)
         node_prefix = "{}(node)".format(prefix)
         parent_prefix = "{}(parent)".format(prefix)
         parentref_prefix = "{}(parentref)".format(prefix)
+
+        for line in ConsolePrinter._debug_dump(data.path, prefix=path_prefix):
+            yield line
 
         for line in ConsolePrinter._debug_dump(data.node, prefix=node_prefix):
             yield line

--- a/yamlpath/wrappers/consoleprinter.py
+++ b/yamlpath/wrappers/consoleprinter.py
@@ -14,7 +14,7 @@ Requires an object on init which has the following properties:
 Copyright 2018, 2019, 2020 William W. Kimball, Jr. MBA MSIS
 """
 import sys
-from typing import Any, Dict, Generator, List, Union
+from typing import Any, Dict, Generator, List, Tuple, Union
 
 from ruamel.yaml.comments import CommentedMap
 
@@ -219,7 +219,7 @@ class ConsolePrinter:
                 data, prefix=prefix, **kwargs
             ):
                 yield line
-        elif isinstance(data, list):
+        elif isinstance(data, (list, tuple)):
             for line in ConsolePrinter._debug_list(
                 data, prefix=prefix, **kwargs
             ):
@@ -271,7 +271,9 @@ class ConsolePrinter:
             yield line
 
     @classmethod
-    def _debug_list(cls, data: List, **kwargs) -> Generator[str, None, None]:
+    def _debug_list(
+        cls, data: Union[List[Any], Tuple[Any, ...]], **kwargs
+    ) -> Generator[str, None, None]:
         """Helper for debug."""
         prefix = kwargs.pop("prefix", "")
         for idx, ele in enumerate(data):

--- a/yamlpath/wrappers/nodecoords.py
+++ b/yamlpath/wrappers/nodecoords.py
@@ -1,6 +1,7 @@
 """Wrap a node along with its relative coordinates within its DOM."""
 from typing import Any
 
+from yamlpath import YAMLPath
 
 class NodeCoords:
     """
@@ -12,7 +13,9 @@ class NodeCoords:
     3. Index-or-Key-of-the-Node-Within-Its-Immediate-Parent
     """
 
-    def __init__(self, node: Any, parent: Any, parentref: Any) -> None:
+    def __init__(
+        self, node: Any, parent: Any, parentref: Any, path: YAMLPath = None
+    ) -> None:
         """
         Initialize a new NodeCoords.
 
@@ -21,6 +24,8 @@ class NodeCoords:
         2. parent (Any) Reference to `node`'s immediate DOM parent
         3. parentref (Any) The `list` index or `dict` key which indicates where
            within `parent` the `node` is located
+        4. path (YAMLPath) The YAML Path for this node, as reported by its
+           creator process
 
         Returns: N/A
 
@@ -29,6 +34,7 @@ class NodeCoords:
         self.node = node
         self.parent = parent
         self.parentref = parentref
+        self.path = path
 
     def __str__(self) -> str:
         """Get a String representation of this object."""

--- a/yamlpath/yamlpath.py
+++ b/yamlpath/yamlpath.py
@@ -100,9 +100,14 @@ class YAMLPath:
         """Indicate non-equivalence of two YAMLPaths."""
         return not self == other
 
+    def __add__(self, other: object) -> "YAMLPath":
+        """Add a nonmutating -- pre-escaped -- path segment."""
+        next_segment = str(other) if not isinstance(other, str) else other
+        return YAMLPath(self).append(next_segment)
+
     def append(self, segment: str) -> "YAMLPath":
         """
-        Append a new segment to this YAML Path.
+        Append a new -- pre-escaped -- segment to this YAML Path.
 
         Parameters:
         1. segment (str) The new -- pre-escaped -- segment to append to this


### PR DESCRIPTION
3.3.0:
Bug Fixes:
* It was impossible to install yamlpath 3.x without first installing
  ruamel.yaml via pip for Python 3.x.  Not only has this been fixed but
  explicit tests have been created to ensure this never happens again.

Enhancements:
* A new command-line tool, yaml-diff, now compares exactly two
  YAML/JSON/Compatible documents, producing a GNU diff-like report of any
  differences in the data they present to parsers.  Along with diff's "a"
  (added), "c" (changed), and "d" (deleted) report entries, affected YAML Paths
  are printed in lieu of line numbers.  Further, a report entry of "s" (same)
  is available and can be enabled via command-line options.  This tool also
  features optional special handling of Arrays and Arrays-of-Hashes, which can
  be configured as CLI options or via an INI file for distinct settings per
  YAML Path.  See --help or the Wiki for more detail.

API Changes:
* NodeCoords now employ a new `path` attribute.  This is an optional parameter
  which is assigned during construction to later report the translated origin
  YAML Path; this is where the node was found or created within the DOM.  Note
  that Collector segments work against virtual DOMs, so the YAML Path of an
  outer Collector will be virtual, relative to its parent at construction; when
  nested, this will be a bare list index.  Any NodeCoords in the virtual
  container which point to real nodes in the DOM will have their own concrete
  YAML Paths.
* YAMLPath instances now support nonmutating addition of individual segments
  via the + operator.  Whereas the append() method mutates the YAMLPath being
  acted upon, + creates a new YAMLPath that is the original plus the new
  segment.  In both cases, the orignal YAMLPath's seperator is retained during
  both operations.  As with .append(), new segments added via + must also be
  properly escaped -- typically via path.escape_path_section -- before being
  added.
