### PR TITLE
Release 3.6.3

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+3.6.3
+Bug Fixes:
+* The eyaml-rotate-keys command-line tool failed to preserve block-style EYAML
+  strings after key rotation.
+
 3.6.2:
 Bug Fixes:
 * The eyaml-rotate-keys command-line tool would generate a stack-dump when the

--- a/tests/test_commands_eyaml_rotate_keys.py
+++ b/tests/test_commands_eyaml_rotate_keys.py
@@ -59,7 +59,12 @@ class Test_eyaml_rotate_keys():
         assert "Not a file:" in result.stderr
 
     @requireseyaml
-    def test_good_multi_replacements(self, script_runner, tmp_path_factory, old_eyaml_keys, new_eyaml_keys):
+    def test_good_multi_replacements(self, script_runner, tmp_path_factory, old_eyaml_keys, new_eyaml_keys, quiet_logger):
+        from yamlpath.func import unwrap_node_coords
+        from yamlpath.common import Parsers
+        from yamlpath import Processor
+        from yamlpath.eyaml import EYAMLProcessor
+
         simple_content = """---
         encrypted_string: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAHA4rPcTzvgzPLtnGz3yoyX/kVlQ5TnPXcScXK2bwjguGZLkuzv/JVPAsOm4t6GlnROpy4zb/lUMHRJDChJhPLrSj919B8//huoMgw0EU5XTcaN6jeDDjL+vhjswjvLFOux66UwvMo8sRci/e2tlFiam8VgxzV0hpF2qRrL/l84V04gL45kq4PCYDWrJNynOwYVbSIF+qc5HaF25H8kHq1lD3RB6Ob/J942Q7k5Qt7W9mNm9cKZmxwgtUgIZWXW6mcPJ2dXDB/RuPJJSrLsb1VU/DkhdgxaNzvLCA+MViyoFUkCfHFNZbaHKNkoYXBy7dLmoh/E5tKv99FeG/7CzL3DBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCVU5Mjt8+4dLkoqB9YArfkgCDkdIhXR9T1M4YYa1qTE6by61VPU3g1aMExRmo4tNZ8FQ==]
         encrypted_block: >
@@ -114,7 +119,53 @@ class Test_eyaml_rotate_keys():
         assert not simple_data == simple_content
         assert not anchored_data == anchored_content
 
-        # FIXME:  Verify that block and string formatting is correct
+        # Verify that block and string formatting is correct
+        yaml = Parsers.get_yaml_editor()
+
+        (yaml_rotated_data, doc_loaded) = Parsers.get_yaml_data(
+            yaml, quiet_logger,
+            anchored_data, literal=True)
+        if not doc_loaded:
+            # An error message has already been logged
+            assert False, "Rotated anchored data failed to load"
+
+        source_processor = Processor(quiet_logger, yaml_rotated_data)
+        for node in source_processor.get_nodes('/block', mustexist=True):
+            assert not '  ' in unwrap_node_coords(node)
+
+
+        # Test that the pre- and post-rotated values are identical
+        (yaml_anchored_data, doc_loaded) = Parsers.get_yaml_data(
+            yaml, quiet_logger,
+            anchored_content, literal=True)
+        if not doc_loaded:
+            # An error message has already been logged
+            assert False, "Original anchored data failed to load"
+
+        (yaml_rotated_data, doc_loaded) = Parsers.get_yaml_data(
+            yaml, quiet_logger,
+            anchored_data, literal=True)
+        if not doc_loaded:
+            # An error message has already been logged
+            assert False, "Rotated anchored data failed to load"
+
+        source_processor = EYAMLProcessor(
+            quiet_logger, yaml_anchored_data,
+            privatekey=old_eyaml_keys[0],
+            publickey=old_eyaml_keys[1])
+        for node in source_processor.get_eyaml_values(
+            '/block', True
+        ):
+            assert unwrap_node_coords(node) == 'This is a test value.'
+
+        rotated_processor = EYAMLProcessor(
+            quiet_logger, yaml_rotated_data,
+            privatekey=new_eyaml_keys[0],
+            publickey=new_eyaml_keys[1])
+        for node in rotated_processor.get_eyaml_values(
+            '/block', True
+        ):
+            assert unwrap_node_coords(node) == 'This is a test value.'
 
     def test_yaml_parsing_error(self, script_runner, imparsible_yaml_file, old_eyaml_keys, new_eyaml_keys):
         result = script_runner.run(

--- a/yamlpath/__init__.py
+++ b/yamlpath/__init__.py
@@ -1,6 +1,6 @@
 """Core YAML Path classes."""
 # Establish the version number common to all components
-__version__ = "3.6.2"
+__version__ = "3.6.3"
 
 from yamlpath.yamlpath import YAMLPath
 from yamlpath.processor import Processor

--- a/yamlpath/commands/eyaml_rotate_keys.py
+++ b/yamlpath/commands/eyaml_rotate_keys.py
@@ -17,6 +17,7 @@ from ruamel.yaml.scalarstring import FoldedScalarString
 from yamlpath import __version__ as YAMLPATH_VERSION
 from yamlpath.common import Anchors, Parsers
 from yamlpath.eyaml.exceptions import EYAMLCommandException
+from yamlpath.eyaml.enums import EYAMLOutputFormats
 from yamlpath.eyaml import EYAMLProcessor
 from yamlpath.wrappers import ConsolePrinter
 
@@ -163,9 +164,9 @@ def main():
 
                 # Prefer block (folded) values unless the original YAML value
                 # was already a massivly long (string) line.
-                output = "block"
+                output = EYAMLOutputFormats.BLOCK
                 if not isinstance(node, FoldedScalarString):
-                    output = "string"
+                    output = EYAMLOutputFormats.STRING
 
                 # Re-encrypt the value with new EYAML keys
                 processor.publickey = args.newpublickey

--- a/yamlpath/processor.py
+++ b/yamlpath/processor.py
@@ -163,8 +163,7 @@ class Processor:
 
         if mustexist:
             self.logger.debug(
-                "Processor::set_value:  Seeking required node at {}."
-                .format(yaml_path)
+                f"Processor::set_value:  Seeking required node at {yaml_path}."
             )
             found_nodes: int = 0
             for req_node in self._get_required_nodes(self.data, yaml_path):
@@ -216,10 +215,9 @@ class Processor:
                                                     YAMLValueFormats.DEFAULT)
         tag: str = kwargs.pop("tag", None)
 
-        self.logger.debug((
-            "Attempting to change a node coordinate of type {} to value with"
-            " format <{}>:"
-            ).format(type(node_coord), value_format),
+        self.logger.debug(
+            "Attempting to change a node coordinate of type"
+            f" {type(node_coord)} to value with format <{value_format}>:",
             data={
                 "value": value,
                 "node_coord": node_coord
@@ -2349,7 +2347,7 @@ class Processor:
             change_node, value, value_format, tag=value_tag)
 
         self.logger.debug(
-            "Changing the following <{}> formatted node:".format(value_format),
+            f"Changing the following <{value_format}> formatted node:",
             prefix="Processor::_update_node:  ",
             data={ "__FROM__": change_node, "___TO___": new_node })
 


### PR DESCRIPTION
Bug Fixes:
* The eyaml-rotate-keys command-line tool failed to preserve block-style EYAML
  strings after key rotation.
