### PR TITLE
Improve py 3.10 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,11 +32,11 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install --upgrade setuptools
         python -m pip install --upgrade wheel
-        python -m pip install --upgrade mypy pytest pytest-cov pytest-console-scripts pylint coveralls pep257
+        python -m pip install --upgrade mypy pytest pytest-cov pytest-console-scripts pylint coveralls pydocstyle
         python -m pip install --editable .
-    - name: Validate Compliance with PEP257
+    - name: Validate Compliance with pydocstyle
       run: |
-        pep257 yamlpath
+        pydocstyle yamlpath
     - name: Validate Compliance with MyPY
       run: |
         mypy yamlpath

--- a/.github/workflows/python-publish-to-test-pypi.yml
+++ b/.github/workflows/python-publish-to-test-pypi.yml
@@ -33,11 +33,11 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install --upgrade setuptools
         python -m pip install --upgrade wheel
-        python -m pip install --upgrade mypy pytest pytest-cov pytest-console-scripts pylint coveralls pep257
+        python -m pip install --upgrade mypy pytest pytest-cov pytest-console-scripts pylint coveralls pydocstyle
         python -m pip install --editable .
-    - name: Validate Compliance with PEP257
+    - name: Validate Compliance with pydocstyle
       run: |
-        pep257 yamlpath
+        pydocstyle yamlpath
     - name: Validate Compliance with MyPY
       run: |
         mypy yamlpath

--- a/run-tests.ps1
+++ b/run-tests.ps1
@@ -66,14 +66,14 @@ ForEach ($EnvDir in $EnvDirs) {
     }
 
     Write-Output "...upgrading testing tools"
-    pip install --upgrade mypy pytest pytest-cov pytest-console-scripts pylint coveralls pep257
+    pip install --upgrade mypy pytest pytest-cov pytest-console-scripts pylint coveralls pydocstyle
 
-    Write-Output "`nPEP257..."
-    pep257 yamlpath | Out-String
+    Write-Output "`nPYDOCSTYLE..."
+    pydocstyle yamlpath | Out-String
     if (!$?) {
         & deactivate
         Remove-Item -Recurse -Force $TmpVEnv
-        Write-Error "PEP257 Error: $?"
+        Write-Error "PYDOCSTYLE Error: $?"
         exit 9
     }
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -67,13 +67,13 @@ EOF
 
 	echo "...upgrading testing tools"
 	pip install --upgrade mypy pytest pytest-cov pytest-console-scripts \
-		pylint coveralls pep257 >/dev/null
+		pylint coveralls pydocstyle >/dev/null
 
-	echo -e "\nPEP257..."
-	if ! pep257 yamlpath; then
+	echo -e "\nPYDOCSTYLE..."
+	if ! pydocstyle yamlpath; then
 		deactivate
 		rm -rf "$tmpVEnv"
-		echo "PEP257 Error: $?"
+		echo "PYDOCSTYLE Error: $?"
 		exit 9
 	fi
 

--- a/yamlpath/commands/eyaml_rotate_keys.py
+++ b/yamlpath/commands/eyaml_rotate_keys.py
@@ -97,7 +97,10 @@ def validateargs(args, log):
 
 # pylint: disable=locally-disabled,too-many-locals,too-many-branches,too-many-statements
 def main():
-    """Main code."""
+    """Perform the work specified via CLI arguments and exit.
+
+    Main code.
+    """
     # Process any command-line arguments
     args = processcli()
     log = ConsolePrinter(args)

--- a/yamlpath/commands/yaml_diff.py
+++ b/yamlpath/commands/yaml_diff.py
@@ -267,7 +267,10 @@ def get_doc(log, docs, index):
 
 # pylint: disable=locally-disabled,too-many-locals
 def main():
-    """Main code."""
+    """Perform the work specified via CLI arguments and exit.
+
+    Main code.
+    """
     args = processcli()
     log = ConsolePrinter(args)
     validateargs(args, log)

--- a/yamlpath/commands/yaml_get.py
+++ b/yamlpath/commands/yaml_get.py
@@ -153,7 +153,10 @@ def validateargs(args, log):
         sys.exit(1)
 
 def main():
-    """Main code."""
+    """Perform the work specified via CLI arguments and exit.
+
+    Main code.
+    """
     args = processcli()
     log = ConsolePrinter(args)
     validateargs(args, log)

--- a/yamlpath/commands/yaml_merge.py
+++ b/yamlpath/commands/yaml_merge.py
@@ -456,7 +456,10 @@ def merge_docs(
     return return_state
 
 def main():
-    """Main code."""
+    """Perform the work specified via CLI arguments and exit.
+
+    Main code.
+    """
     args = processcli()
     log = ConsolePrinter(args)
     validateargs(args, log)

--- a/yamlpath/commands/yaml_paths.py
+++ b/yamlpath/commands/yaml_paths.py
@@ -870,7 +870,10 @@ def process_yaml_file(
     return exit_state
 
 def main():
-    """Main code."""
+    """Perform the work specified via CLI arguments and exit.
+
+    Main code.
+    """
     # Process any command-line arguments
     args = processcli()
     log = ConsolePrinter(args)

--- a/yamlpath/commands/yaml_set.py
+++ b/yamlpath/commands/yaml_set.py
@@ -452,7 +452,10 @@ def _ymk_nodes(
 
 # pylint: disable=locally-disabled,too-many-locals,too-many-branches,too-many-statements
 def main():
-    """Main code."""
+    """Perform the work specified via CLI arguments and exit.
+
+    Main code.
+    """
     args = processcli()
     log = ConsolePrinter(args)
     validateargs(args, log)

--- a/yamlpath/commands/yaml_validate.py
+++ b/yamlpath/commands/yaml_validate.py
@@ -125,7 +125,10 @@ def process_file(log, yaml, yaml_file):
     return exit_state
 
 def main():
-    """Main code."""
+    """Perform the work specified via CLI arguments and exit.
+
+    Main code.
+    """
     # Process any command-line arguments
     args = processcli()
     log = ConsolePrinter(args)

--- a/yamlpath/common/nodes.py
+++ b/yamlpath/common/nodes.py
@@ -4,7 +4,6 @@ Implement Nodes, a static library of generally-useful code for data nodes.
 Copyright 2020 William W. Kimball, Jr. MBA MSIS
 """
 from ast import literal_eval
-from distutils.util import strtobool
 from typing import Any
 
 from ruamel.yaml.comments import CommentedSeq, CommentedMap, TaggedScalar
@@ -117,7 +116,7 @@ class Nodes:
             if isinstance(value, bool):
                 new_value = value
             else:
-                new_value = strtobool(value)
+                new_value = Nodes.str_to_truth_int(value)
         elif valform == YAMLValueFormats.FLOAT:
             try:
                 new_value = float(value)
@@ -485,3 +484,22 @@ class Nodes:
         except SyntaxError:
             typed_value = value
         return typed_value
+
+    @staticmethod
+    def str_to_truth_int(value: str) -> int:
+        """
+        Convert a string representation of truth to true (1) or false (0).
+
+        True values are 'y', 'yes', 't', 'true', 'on' and '1';
+        False values are 'n', 'no', 'f', 'false', 'off' and '0'.
+        Raises ValueError if val is anything else.
+
+        As advised by PEP632, this function implements distutils.util.strtobool
+        from the official Python 3.9 documentation.
+        """
+        lower_value = value.lower() if value else value
+        if lower_value in ('y', 'yes', 't', 'true', 'on', '1'):
+            return 1
+        if lower_value in ('n', 'no', 'f', 'false', 'off', '0'):
+            return 0
+        raise ValueError("'{}' is not a representation of truth".format(value))

--- a/yamlpath/processor.py
+++ b/yamlpath/processor.py
@@ -1465,7 +1465,10 @@ class Processor:
         self, data: Any, peek_path: YAMLPath, node_coords: List[NodeCoords],
         **kwargs
     ) -> List[NodeCoords]:
-        """Helper for _get_nodes_by_collector."""
+        """List nodes matching the given path of an Addition Collector.
+
+        Helper for _get_nodes_by_collector.
+        """
         updated_coords = node_coords
         parent: Any = kwargs.pop("parent", None)
         parentref: Any = kwargs.pop("parentref", None)
@@ -1503,7 +1506,10 @@ class Processor:
         self, data: Any, peek_path: YAMLPath, collected_ncs: List[NodeCoords],
         **kwargs
     ) -> List[NodeCoords]:
-        """Helper for _get_nodes_by_collector."""
+        """List nodes matching the given path of a Subtraction Collector.
+
+        Helper for _get_nodes_by_collector.
+        """
         def get_del_nodes(
             del_nodes: List[Any], node_coord: NodeCoords
         ) -> None:

--- a/yamlpath/wrappers/consoleprinter.py
+++ b/yamlpath/wrappers/consoleprinter.py
@@ -206,12 +206,10 @@ class ConsolePrinter:
 
     @staticmethod
     def _debug_prefix_lines(line: str) -> str:
-        """Helper for debug."""
         return "DEBUG:  {}".format(str(line).replace("\n", "\nDEBUG:  "))
 
     @staticmethod
     def _debug_get_anchor(data: Any) -> str:
-        """Helper for debug."""
         return ("&{}".format(data.anchor.value)
                 if (hasattr(data, "anchor")
                     and hasattr(data.anchor, "value")
@@ -220,7 +218,6 @@ class ConsolePrinter:
 
     @staticmethod
     def _debug_get_tag(data: Any) -> str:
-        """Helper for debug."""
         return str(data.tag.value
                 if (hasattr(data, "tag")
                     and hasattr(data.tag, "value")
@@ -229,7 +226,6 @@ class ConsolePrinter:
 
     @staticmethod
     def _debug_dump(data: Any, **kwargs) -> Generator[str, None, None]:
-        """Helper for debug."""
         prefix = kwargs.pop("prefix", "")
         if isinstance(data, dict):
             for line in ConsolePrinter._debug_dict(
@@ -256,7 +252,6 @@ class ConsolePrinter:
 
     @staticmethod
     def _debug_scalar(data: Any, **kwargs) -> str:
-        """Helper for debug."""
         prefix = kwargs.pop("prefix", "")
         print_anchor = kwargs.pop("print_anchor", True)
         print_tag = kwargs.pop("print_tag", True)
@@ -295,7 +290,6 @@ class ConsolePrinter:
     def _debug_node_coord(
         data: NodeCoords, **kwargs
     ) -> Generator[str, None, None]:
-        """Helper method for debug."""
         prefix = kwargs.pop("prefix", "")
         path_prefix = "{}(path)".format(prefix)
         segment_prefix = "{}(segment)".format(prefix)
@@ -334,7 +328,6 @@ class ConsolePrinter:
     def _debug_list(
         data: Union[List[Any], Set[Any], Tuple[Any, ...], Deque[Any]], **kwargs
     ) -> Generator[str, None, None]:
-        """Helper for debug."""
         prefix = kwargs.pop("prefix", "")
         print_tag = kwargs.pop("print_tag", True)
 
@@ -362,7 +355,6 @@ class ConsolePrinter:
 
     @staticmethod
     def _debug_get_kv_anchors(key: Any, value: Any) -> str:
-        """Helper for debug."""
         key_anchor = ConsolePrinter._debug_get_anchor(key)
         val_anchor = ConsolePrinter._debug_get_anchor(value)
         display_anchor = ""
@@ -376,7 +368,6 @@ class ConsolePrinter:
 
     @staticmethod
     def _debug_get_kv_tags(key: Any, value: Any) -> str:
-        """Helper for debug."""
         key_tag = ConsolePrinter._debug_get_tag(key)
         val_tag = ConsolePrinter._debug_get_tag(value)
         display_tag = ""
@@ -392,7 +383,6 @@ class ConsolePrinter:
     def _debug_dict(
         data: Union[Dict, CommentedMap], **kwargs
     ) -> Generator[str, None, None]:
-        """Helper for debug."""
         prefix = kwargs.pop("prefix", "")
 
         local_keys = []
@@ -422,7 +412,6 @@ class ConsolePrinter:
     def _debug_set(
         data: Union[Set, CommentedSet], **kwargs
     ) -> Generator[str, None, None]:
-        """Helper for debug."""
         prefix = kwargs.pop("prefix", "")
 
         for key in data:


### PR DESCRIPTION
This PR...
- Attempts to fix (fully or partially) #166.
- Replaces `pep257` (now unmaintained) with its explicit successor `pydocstyle` (see [pep257's Homepage redirect](https://pypi.org/project/pep257/) or [its docs' introduction](https://pep257.readthedocs.io/en/latest/)).
  - `pep257` cannot be used with Python 3.10 or later.
  - `pydocstyle` support starts at Python 3.6, same as yamlpath, so there is no need to maintain dual imports or somesuch.
- Makes minimal documentation changes to meet `pydocstyle`'s more extensive PEP 257 rules.
  - A better way to handle all the `main()`s may be to remove them from `__all__`, or otherwise make them private, but I wanted to avoid introducing any meaningful code changes (someone may be importing one of those `main()`s for all I know).
  - I removed non-compliant documentation that did not add context/information instead of rewriting it, let me know if that's not acceptable.
- Replaces single use of `distutils`, a call to `distutils.utils.strtobool`, with an internal re-implementation based on [the legacy documentation](https://docs.python.org/3.9/distutils/apiref.html#distutils.util.strtobool), per [PEP 632's advice](https://peps.python.org/pep-0632/#migration-advice).
  - `distutils` imports raise a deprecation warning starting with Python 3.10 (breaking yamlpath), and will be removed with Python 3.11.
  - Used functionality is identical, and it's a tiny piece of code, so thought it'd be okay to replace wholesale. If not, could instead do a `try import/except shim` so Python 3.9 and older keep using distutils.

This PR does not guarantee that yamlpath now supports Python 3.10. It fixes my downstream issues consuming the package, allows linting to work on Python 3.10, and did not seem to break any existing tests on my local build (was unable to run eyaml tests on any version/branch due to strange ruby encoding issues).

Hence, this PR does _not_ mark this package as 3.10-compatible or add a Python 3.10 build.

Sorry for the "drive-by" nature of the contribution, but I _am_ interested in the long-term health of this project, and happy to contribute more to it.