### PR TITLE
Prepare v3.6.5 for release

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,7 @@ Bug Fixes:
   was broken when written to YAML, corrupting the YAML file.  Non-block
   formatted values were unaffected and this issue only affected Windows EYAML
   users.
+* EYAML values were not being decrypted when the result appeared in a list.
 
 3.6.4
 Enhancements:

--- a/CHANGES
+++ b/CHANGES
@@ -5,6 +5,11 @@ Bug Fixes:
   formatted values were unaffected and this issue only affected Windows EYAML
   users.
 * EYAML values were not being decrypted when the result appeared in a list.
+* Boolean values were being unexpectedly output as base-10 representations of
+  the binary values 1 (True) and 0 (False) when emitting to JSON after setting
+  the Boolean.  This change also brings this project into compilance with
+  https://peps.python.org/pep-0632/.  Many thanks to
+  https://github.com/AndydeCleyre!
 
 3.6.4
 Enhancements:

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,10 @@
+3.6.5
+Bug Fixes:
+* When using EYAML with block formatted values on Windows, the block formatting
+  was broken when written to YAML, corrupting the YAML file.  Non-block
+  formatted values were unaffected and this issue only affected Windows EYAML
+  users.
+
 3.6.4
 Enhancements:
 * Support ruamel.yaml up to version 0.17.17.

--- a/tests/test_commands_eyaml_rotate_keys.py
+++ b/tests/test_commands_eyaml_rotate_keys.py
@@ -66,36 +66,36 @@ class Test_eyaml_rotate_keys():
         from yamlpath.eyaml import EYAMLProcessor
 
         simple_content = """---
-        encrypted_string: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAHA4rPcTzvgzPLtnGz3yoyX/kVlQ5TnPXcScXK2bwjguGZLkuzv/JVPAsOm4t6GlnROpy4zb/lUMHRJDChJhPLrSj919B8//huoMgw0EU5XTcaN6jeDDjL+vhjswjvLFOux66UwvMo8sRci/e2tlFiam8VgxzV0hpF2qRrL/l84V04gL45kq4PCYDWrJNynOwYVbSIF+qc5HaF25H8kHq1lD3RB6Ob/J942Q7k5Qt7W9mNm9cKZmxwgtUgIZWXW6mcPJ2dXDB/RuPJJSrLsb1VU/DkhdgxaNzvLCA+MViyoFUkCfHFNZbaHKNkoYXBy7dLmoh/E5tKv99FeG/7CzL3DBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCVU5Mjt8+4dLkoqB9YArfkgCDkdIhXR9T1M4YYa1qTE6by61VPU3g1aMExRmo4tNZ8FQ==]
-        encrypted_block: >
-          ENC[PKCS7,MIIBeQYJKoZIhvcNAQcDoIIBajCCAWYCAQAxggEhMIIBHQIBADAFMAACAQEw
-          DQYJKoZIhvcNAQEBBQAEggEAnxQVqyIgRTb/+VP4Q+DLJcnlS8YPouXEW8+z
-          it9uwUA02CEPxCEU944GcHpgTY3EEtkm+2Z/jgXI119VMML+OOQ1NkwUiAw/
-          wq0vwz2D16X31XzhedQN5FZbfZ1C+2tWSQfCjE0bu7IeHfyR+k2ssD11kNZh
-          JDEr2bM2dwOdT0y7VGcQ06vI9gw6UXcwYAgS6FoLm7WmFftjcYiNB+0EJSW0
-          VcTn2gveaw9iOQcum/Grby+9Ybs28fWd8BoU+ZWDpoIMEceujNa9okIXNPJO
-          jcvv1sgauwJ3RX6WFQIy/beS2RT5EOLhWIZCAQCcgJWgovu3maB7dEUZ0NLG
-          OYUR7zA8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBAbO16EzQ5/cdcvgB0g
-          tpKIgBAEgTLT5n9Jtc9venK0CKso]
-        """
+encrypted_string: ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAHA4rPcTzvgzPLtnGz3yoyX/kVlQ5TnPXcScXK2bwjguGZLkuzv/JVPAsOm4t6GlnROpy4zb/lUMHRJDChJhPLrSj919B8//huoMgw0EU5XTcaN6jeDDjL+vhjswjvLFOux66UwvMo8sRci/e2tlFiam8VgxzV0hpF2qRrL/l84V04gL45kq4PCYDWrJNynOwYVbSIF+qc5HaF25H8kHq1lD3RB6Ob/J942Q7k5Qt7W9mNm9cKZmxwgtUgIZWXW6mcPJ2dXDB/RuPJJSrLsb1VU/DkhdgxaNzvLCA+MViyoFUkCfHFNZbaHKNkoYXBy7dLmoh/E5tKv99FeG/7CzL3DBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCVU5Mjt8+4dLkoqB9YArfkgCDkdIhXR9T1M4YYa1qTE6by61VPU3g1aMExRmo4tNZ8FQ==]
+encrypted_block: >
+  ENC[PKCS7,MIIBeQYJKoZIhvcNAQcDoIIBajCCAWYCAQAxggEhMIIBHQIBADAFMAACAQEw
+  DQYJKoZIhvcNAQEBBQAEggEAnxQVqyIgRTb/+VP4Q+DLJcnlS8YPouXEW8+z
+  it9uwUA02CEPxCEU944GcHpgTY3EEtkm+2Z/jgXI119VMML+OOQ1NkwUiAw/
+  wq0vwz2D16X31XzhedQN5FZbfZ1C+2tWSQfCjE0bu7IeHfyR+k2ssD11kNZh
+  JDEr2bM2dwOdT0y7VGcQ06vI9gw6UXcwYAgS6FoLm7WmFftjcYiNB+0EJSW0
+  VcTn2gveaw9iOQcum/Grby+9Ybs28fWd8BoU+ZWDpoIMEceujNa9okIXNPJO
+  jcvv1sgauwJ3RX6WFQIy/beS2RT5EOLhWIZCAQCcgJWgovu3maB7dEUZ0NLG
+  OYUR7zA8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBAbO16EzQ5/cdcvgB0g
+  tpKIgBAEgTLT5n9Jtc9venK0CKso]
+"""
         anchored_content = """---
-        aliases:
-          - &blockStyle >
-            ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEw
-            DQYJKoZIhvcNAQEBBQAEggEArvk6OYa1gACTdrWq2SpCrtGRlc61la5AGU7L
-            aLTyKfqD9vqx71RDjobfOF96No07kLsEpoAJ+LKKHNjdG6kjvpGPmttj9Dkm
-            XVoU6A+YCmm4iYFKD/NkoSOEyAkoDOXSqdjrgt0f37GefEsXt6cqAavDpUJm
-            pmc0KI4TCG5zpfCxqttMs+stOY3Y+0WokkulQujZ7K3SdWUSHIysgMrWiect
-            Wdg5unxN1A/aeyvhgvYSNPjU9KBco7SDnigSs9InW/QghJFrZRrDhTp1oTUc
-            qK5lKvaseHkVGi91vPWeLQxZt1loJB5zL6j5BxMbvRfJK+wc3ax2u4x8WTAB
-            EurCwzBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBAwcy7jvcOGcMfLEtug
-            LEXbgCBkocdckuDe14mVGmUmM++xN34OEVRCeGVWWUnWq1DJ4Q==]
-          - &stringStyle ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAIu44u62q5sVfzC7kytLi2Z/EzH2DKr4vDsoqDBeSZ71aRku/uSrjyiO4lyoq9Kva+eBAyjBay5fnqPVBaU3Rud2pdEoZEoyofi02jn4hxUKpAO1W0AUgsQolGe53qOdM4U8RbwnTR0gr3gp2mCd18pH3SRMP9ryrsBAxGzJ6mR3RgdZnlTlqVGXCeWUeVpbH+lcHw3uvd+o/xkvJ/3ypxz+rWILiAZ3QlCirzn/qb2fHuKf3VBh8RVFuQDaM5voajZlgjD6KzNCsbATOqOA6eJI4j0ngPdDlIjGHAnahuyluQ5f5SIaIjLC+ZeCOfIYni0MQ+BHO0JNbccjq2Unb7TBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCYmAI0Ao3Ok1cSmVw0SgQGgCBK62z1r5RfRjf1xKfqDxTsGUHfsUmM3EjGJfnWzCRvuQ==]
-        block: *blockStyle
-        string: *stringStyle
-        yet_another:
-          'more.complex.child': *blockStyle
-        """
+aliases:
+  - &blockStyle >
+    ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEw
+    DQYJKoZIhvcNAQEBBQAEggEArvk6OYa1gACTdrWq2SpCrtGRlc61la5AGU7L
+    aLTyKfqD9vqx71RDjobfOF96No07kLsEpoAJ+LKKHNjdG6kjvpGPmttj9Dkm
+    XVoU6A+YCmm4iYFKD/NkoSOEyAkoDOXSqdjrgt0f37GefEsXt6cqAavDpUJm
+    pmc0KI4TCG5zpfCxqttMs+stOY3Y+0WokkulQujZ7K3SdWUSHIysgMrWiect
+    Wdg5unxN1A/aeyvhgvYSNPjU9KBco7SDnigSs9InW/QghJFrZRrDhTp1oTUc
+    qK5lKvaseHkVGi91vPWeLQxZt1loJB5zL6j5BxMbvRfJK+wc3ax2u4x8WTAB
+    EurCwzBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBAwcy7jvcOGcMfLEtug
+    LEXbgCBkocdckuDe14mVGmUmM++xN34OEVRCeGVWWUnWq1DJ4Q==]
+  - &stringStyle ENC[PKCS7,MIIBiQYJKoZIhvcNAQcDoIIBejCCAXYCAQAxggEhMIIBHQIBADAFMAACAQEwDQYJKoZIhvcNAQEBBQAEggEAIu44u62q5sVfzC7kytLi2Z/EzH2DKr4vDsoqDBeSZ71aRku/uSrjyiO4lyoq9Kva+eBAyjBay5fnqPVBaU3Rud2pdEoZEoyofi02jn4hxUKpAO1W0AUgsQolGe53qOdM4U8RbwnTR0gr3gp2mCd18pH3SRMP9ryrsBAxGzJ6mR3RgdZnlTlqVGXCeWUeVpbH+lcHw3uvd+o/xkvJ/3ypxz+rWILiAZ3QlCirzn/qb2fHuKf3VBh8RVFuQDaM5voajZlgjD6KzNCsbATOqOA6eJI4j0ngPdDlIjGHAnahuyluQ5f5SIaIjLC+ZeCOfIYni0MQ+BHO0JNbccjq2Unb7TBMBgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBCYmAI0Ao3Ok1cSmVw0SgQGgCBK62z1r5RfRjf1xKfqDxTsGUHfsUmM3EjGJfnWzCRvuQ==]
+block: *blockStyle
+string: *stringStyle
+yet_another:
+  'more.complex.child': *blockStyle
+"""
         simple_file = create_temp_yaml_file(tmp_path_factory, simple_content)
         anchored_file = create_temp_yaml_file(tmp_path_factory, anchored_content)
 
@@ -115,6 +115,9 @@ class Test_eyaml_rotate_keys():
 
         with open(anchored_file, 'r') as fhnd:
             anchored_data = fhnd.read()
+            # print("=== DEBUG: START anchored_data ===")
+            # print(anchored_data)
+            # print("=== DEBUG: STOP anchored_data ===")
 
         assert not simple_data == simple_content
         assert not anchored_data == anchored_content
@@ -127,7 +130,7 @@ class Test_eyaml_rotate_keys():
             anchored_data, literal=True)
         if not doc_loaded:
             # An error message has already been logged
-            assert False, "Rotated anchored data failed to load"
+            assert False, "Rotated anchored data failed to load (verify formatting)"
 
         source_processor = Processor(quiet_logger, yaml_rotated_data)
         for node in source_processor.get_nodes('/block', mustexist=True):
@@ -140,14 +143,14 @@ class Test_eyaml_rotate_keys():
             anchored_content, literal=True)
         if not doc_loaded:
             # An error message has already been logged
-            assert False, "Original anchored data failed to load"
+            assert False, "Original anchored data failed to load (verify values)"
 
         (yaml_rotated_data, doc_loaded) = Parsers.get_yaml_data(
             yaml, quiet_logger,
             anchored_data, literal=True)
         if not doc_loaded:
             # An error message has already been logged
-            assert False, "Rotated anchored data failed to load"
+            assert False, "Rotated anchored data failed to load (verify values)"
 
         source_processor = EYAMLProcessor(
             quiet_logger, yaml_anchored_data,

--- a/tests/test_common_parsers.py
+++ b/tests/test_common_parsers.py
@@ -95,16 +95,20 @@ has: different data
             "dates": ry.comments.CommentedSeq([
                 dt.date(2020, 10, 31),
                 dt.date(2020, 11, 3)
-            ])
+            ]),
+            "t_bool": ry.scalarbool.ScalarBoolean(1),
+            "f_bool": ry.scalarbool.ScalarBoolean(0)
         })
         jdata = Parsers.jsonify_yaml_data(cdata)
         assert jdata["tagged"] == tagged_value
         assert jdata["null"] == null_value
         assert jdata["dates"][0] == "2020-10-31"
         assert jdata["dates"][1] == "2020-11-03"
+        assert jdata["t_bool"] == 1
+        assert jdata["f_bool"] == 0
 
         jstr = json.dumps(jdata)
-        assert jstr == """{"tagged": "tagged value", "null": null, "dates": ["2020-10-31", "2020-11-03"]}"""
+        assert jstr == """{"tagged": "tagged value", "null": null, "dates": ["2020-10-31", "2020-11-03"], "t_bool": true, "f_bool": false}"""
 
     def test_jsonify_complex_python_data(self):
         cdata = {
@@ -112,11 +116,15 @@ has: different data
                 dt.date(2020, 10, 31),
                 dt.date(2020, 11, 3)
             ],
-            "bytes": b"abc"
+            "bytes": b"abc",
+            "t_bool": True,
+            "f_bool": False
         }
         jdata = Parsers.jsonify_yaml_data(cdata)
         assert jdata["dates"][0] == "2020-10-31"
         assert jdata["dates"][1] == "2020-11-03"
+        assert jdata["t_bool"] == True
+        assert jdata["f_bool"] == False
 
         jstr = json.dumps(jdata)
-        assert jstr == """{"dates": ["2020-10-31", "2020-11-03"], "bytes": "b'abc'"}"""
+        assert jstr == """{"dates": ["2020-10-31", "2020-11-03"], "bytes": "b'abc'", "t_bool": true, "f_bool": false}"""

--- a/tests/test_eyaml_eyamlprocessor.py
+++ b/tests/test_eyaml_eyamlprocessor.py
@@ -137,6 +137,9 @@ class Test_eyaml_EYAMLProcessor():
     @pytest.mark.parametrize("yaml_path,compare", [
         ("aliases[&secretIdentity]", "This is not the identity you are looking for."),
         ("aliases[&secretPhrase]", "There is no secret phrase."),
+        ("aliases", ["This is not the identity you are looking for.", "There is no secret phrase."]),
+        ("(aliases)", ["This is not the identity you are looking for.", "There is no secret phrase."]),
+        ("((aliases)*)[0]", "This is not the identity you are looking for."),
     ])
     def test_happy_get_eyaml_values(self, quiet_logger, eyamldata_f, old_eyaml_keys, yaml_path, compare):
         processor = EYAMLProcessor(quiet_logger, eyamldata_f, privatekey=old_eyaml_keys[0], publickey=old_eyaml_keys[1])

--- a/yamlpath/__init__.py
+++ b/yamlpath/__init__.py
@@ -1,6 +1,6 @@
 """Core YAML Path classes."""
 # Establish the version number common to all components
-__version__ = "3.6.4"
+__version__ = "3.6.5"
 
 from yamlpath.yamlpath import YAMLPath
 from yamlpath.processor import Processor

--- a/yamlpath/commands/yaml_paths.py
+++ b/yamlpath/commands/yaml_paths.py
@@ -861,6 +861,9 @@ def process_yaml_file(
                         all_anchors=all_anchors):
                     for entry in yaml_paths:
                         if str(result) == str(entry[1]):
+                            # Disable modified-iterating-list because the loop
+                            # is exited immediately upon container change.
+                            # pylint: disable=modified-iterating-list
                             yaml_paths.remove(entry)
                             break  # Entries are already unique
 

--- a/yamlpath/common/nodes.py
+++ b/yamlpath/common/nodes.py
@@ -5,7 +5,6 @@ Copyright 2020 William W. Kimball, Jr. MBA MSIS
 """
 import re
 from ast import literal_eval
-from distutils.util import strtobool
 from typing import Any
 
 from ruamel.yaml.comments import CommentedSeq, CommentedMap, TaggedScalar
@@ -107,7 +106,14 @@ class Nodes:
             if isinstance(value, bool):
                 new_value = value
             else:
-                new_value = strtobool(value)
+                allowed_vals = ["true", "false", "yes", "no", "y", "n",
+                                "t", "f", "1", "0"]
+                str_val = str(value).lower()
+                if str_val not in allowed_vals:
+                    raise ValueError("Boolean values must be one of " +
+                                     ", ".join(allowed_vals))
+                new_value = str(value).lower() in (
+                    "true", "yes", "y", "t", "1")
         elif valform == YAMLValueFormats.FLOAT:
             try:
                 new_value = float(value)

--- a/yamlpath/common/parsers.py
+++ b/yamlpath/common/parsers.py
@@ -14,6 +14,7 @@ from ruamel.yaml.parser import ParserError
 from ruamel.yaml.composer import ComposerError, ReusedAnchorWarning
 from ruamel.yaml.constructor import ConstructorError, DuplicateKeyError
 from ruamel.yaml.scanner import ScannerError
+from ruamel.yaml.scalarbool import ScalarBoolean
 from ruamel.yaml.scalarstring import ScalarString
 from ruamel.yaml.comments import (
     CommentedMap, CommentedSet, CommentedSeq, TaggedScalar
@@ -354,6 +355,8 @@ class Parsers:
             return str(data)
         elif isinstance(data, bytes):
             return str(data)
+        elif isinstance(data, (ScalarBoolean, bool)):
+            return bool(data)
         return data
 
     @staticmethod

--- a/yamlpath/eyaml/eyamlprocessor.py
+++ b/yamlpath/eyaml/eyamlprocessor.py
@@ -247,7 +247,8 @@ class EYAMLProcessor(Processor):
             )
 
         if output is EYAMLOutputFormats.BLOCK:
-            retval = re.sub(r" +", "", retval) + "\n"
+            fixval: str = re.sub(r" ", "", retval.strip())
+            retval = re.sub(r"\r\n", " ", fixval) + "\n"
 
         self.logger.debug(
             f"Encrypted result:\n{retval}",


### PR DESCRIPTION
Bug Fixes:
* When using EYAML with block formatted values on Windows, the block formatting
  was broken when written to YAML, corrupting the YAML file.  Non-block
  formatted values were unaffected and this issue only affected Windows EYAML
  users.
* EYAML values were not being decrypted when the result appeared in a list.
* Boolean values were being unexpectedly output as base-10 representations of
  the binary values 1 (True) and 0 (False) when emitting to JSON after setting
  the Boolean.  This change also brings this project into compilance with
  https://peps.python.org/pep-0632/.  Many thanks to
  https://github.com/AndydeCleyre!
