### PR TITLE
Prep v3.6.6

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -5,10 +5,15 @@ Enhancements:
 Bug Fixes:
 * YAML timestamp values could not be created via yamlpath tools or its library,
   per http://yaml.org/type/timestamp.html.
-  * CAUTION 1:  ruamel.yaml seems to force all timestamps to UTC, so even if
-    you specify timezone data, it will be converted and then stripped.  This is
-    a decision by the author of ruamel.yaml that I don't see any way around in
-    the code, for now.
+  * CAUTION 1:  ruamel.yaml seems to force all timestamps to UTC while it loads
+    YAML/JSON/Compatible data.  So, when the timestamp value contains time-zone
+    data, it will be stripped off after it is applied to the timestamp value.
+    The yamlpath library reverses this when emitting the affected values but if
+    you attempt to load the timestamp values directly in the DOM, you'll end up
+    with the UTC-converted value, stripped of any time-zone specification.  If
+    you need the original, unmodified data as a time-zone aware
+    datetime.datetime value, pass it through the helper method,
+    Nodes.get_timestamp_with_tzinfo(data: AnchoredTimeStamp).
   * CAUTION 2:  In order to support timestamp parsing, this project now depends
     on the python-dateutil library.  Be sure to install it!
   Thanks again go to https://github.com/AndydeCleyre!

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,7 @@
 3.6.6
+Enhancements:
+* Support ruamel.yaml up to version 0.17.21.
+
 Bug Fixes:
 * YAML timestamp values could not be created via yamlpath tools or its library,
   per http://yaml.org/type/timestamp.html.

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,15 @@
+3.6.6
+Bug Fixes:
+* YAML timestamp values could not be created via yamlpath tools or its library,
+  per http://yaml.org/type/timestamp.html.
+  * CAUTION 1:  ruamel.yaml seems to force all timestamps to UTC, so even if
+    you specify timezone data, it will be converted and then stripped.  This is
+    a decision by the author of ruamel.yaml that I don't see any way around in
+    the code, for now.
+  * CAUTION 2:  In order to support timestamp parsing, this project now depends
+    on the python-dateutil library.  Be sure to install it!
+  Thanks again go to https://github.com/AndydeCleyre!
+
 3.6.5
 Bug Fixes:
 * When using EYAML with block formatted values on Windows, the block formatting

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ expressions:
 5. `aliases[.%string]` (search for any elements containing "string")
 6. `aliases[.$value]` (search for any elements ending with "value")
 7. `aliases[.=~/^(\b[Ss][a-z]+\s){2}[a-z]+$/]` (search for any elements matching
-   a complex Regular Expression, which happens to match the example)
+   a complex Python Regular Expression, which happens to match the example)
 8. `/aliases[0]` (same as 1 but in forward-slash notation)
 9. `/aliases/0` (same as 2 but in forward-slash notation)
 10. `/aliases[&first_anchor]` (same as 3 but in forward-slash notation)
@@ -188,7 +188,8 @@ YAML Path understands these segment types:
   * Greater Than match: `hash[access_level>0]`
   * Less Than or Equal match: `hash[access_level<=100]`
   * Greater Than or Equal match: `hash[access_level>=0]`
-  * Regular Expression matches: `hash[access_level=~/^\D+$/]` (the `/` Regular
+  * [Python Regular Expression](https://docs.python.org/3/library/re.html)
+    matches: `hash[access_level=~/^\D+$/]` (the `/` Regular
     Expression delimiter can be substituted for any character you need, except
     white-space; note that `/` does not interfere with forward-slash notation
     *and it does not need to be escaped* because the entire search expression is

--- a/README.md
+++ b/README.md
@@ -273,10 +273,11 @@ all -- came pre-installed.  It is generally safe to have more than one version
 of Python on your system at the same time, especially when using
 [virtual Python environments](https://docs.python.org/3/library/venv.html).
 
-*yamlpath* depends on *ruamel.yaml* (derived from and greatly extending PyYAML).
-When using OS-native packages or `pip`, you do not need to pre-install
-*ruamel.yaml* except under extraordinary circumstances like using very old
-versions of `pip` or its own dependency, *setuptools*.
+*yamlpath* depends on *ruamel.yaml* (derived from and greatly extending PyYAML)
+and *python-dateutil*.  When using OS-native packages or `pip`, you do not need
+to pre-install these libraries yourself except under extraordinary
+circumstances like using very old versions of `pip` or its own dependency,
+*setuptools*.
 
 ### Using pip
 
@@ -293,8 +294,8 @@ with Python.  It is your responsibility to keep `pip` and *setuptools*
 up-to-date.  When `pip` or *setuptools* become outdated, _you will experience
 errors_ when trying to install newer Python packages like *yamlpath* **unless
 you preinstall such packages' dependencies**.  In the case of *yamlpath*, this
-means you'd need to preinstall *ruamel.yaml* if you cannot or choose not to
-upgrade `pip` and/or *setuptools*.
+means you'd need to preinstall *ruamel.yaml* and *python-dateutil* if you
+cannot or choose not to upgrade `pip` and/or *setuptools*.
 
 As long as your `pip` and *setuptools* are up-to-date, installing *yamlpath* is
 as simple as a single command (the "3.7" suffix to the `pip` command is
@@ -310,9 +311,9 @@ Very old versions of Python 3 ship with seriously outdated versions of `pip` and
 its *setuptools* dependency.  When using versions of `pip` older than **18.1**
 or *setuptools* older than version **46.4.0**, you will not be able to install
 *yamlpath* with a single command.  In this case, you have two options:  either
-pre-install *ruamel.yaml* before installing *yamlpath* or update `pip` and/or
-*setuptools* to at least the minimum required versions so `pip` can
-auto-determine and install dependencies.  This issue is not unique to
+pre-install *ruamel.yaml* and *python-dateutil* before installing *yamlpath* or
+update `pip` and/or *setuptools* to at least the minimum required versions so
+`pip` can auto-determine and install dependencies.  This issue is not unique to
 *yamlpath*.
 
 Upgrading `pip` and *setuptools* is trivially simple as long as you have
@@ -329,21 +330,22 @@ pip3.7 install --upgrade setuptools
 ```
 
 When you cannot or will not update `pip` or *setuptools*, just pre-install
-*ruamel.yaml* before yamlpath.  Each must be installed seperately and in order,
-like this (you **cannot** combine these installations into a single command):
+*ruamel.yaml* and *python-dateutil* before yamlpath.  Each must be installed
+seperately and in order, like this (you **cannot** combine these installations
+into a single command):
 
 ```shell
-pip3.7 install ruamel.yaml
+pip3.7 install ruamel.yaml python-dateutil
 pip3.7 install yamlpath
 ```
 
 The downside to choosing this manual installation path is that you may end up
-with an incompatible version of *ruamel.yaml*.  This will manifest either as an
-inability to install *yamlpath* at all, or only certain versions of *yamlpath*,
-or *yamlpath* may experience unexpected errors caused by the incompatible code.
-For the best experience, you are strongly encouraged to just keep `pip` and
-*setuptools* up-to-date, particularly as a routine part of installing any new
-Python packages.
+with an incompatible version of *ruamel.yaml* or *python-dateutil*.  This will
+manifest either as an inability to install *yamlpath* at all, or only certain
+versions of *yamlpath*, or *yamlpath* may experience unexpected errors caused
+by the incompatible code.  For the best experience, you are strongly encouraged
+to just keep `pip` and *setuptools* up-to-date, particularly as a routine part
+of installing any new Python packages.
 
 ### Installing EYAML (Optional)
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,3 +4,9 @@ warn_unused_configs = True
 
 [mypy-ruamel.*]
 ignore_missing_imports = True
+
+[mypy-dateutil.*]
+ignore_missing_imports = True
+
+[mypy-yamlpath.patches.*]
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ setup(
     },
     python_requires=">3.6.0",
     install_requires=[
-        "ruamel.yaml>=0.15.96,!=0.17.0,!=0.17.1,!=0.17.2,!=0.17.5,<=0.17.17",
+        "ruamel.yaml>=0.15.96,!=0.17.0,!=0.17.1,!=0.17.2,!=0.17.5,!=0.17.18,<=0.17.21",
+        "python-dateutil<=3"
     ],
     tests_require=[
         "pytest",

--- a/tests/test_commands_yaml_get.py
+++ b/tests/test_commands_yaml_get.py
@@ -160,11 +160,13 @@ nullthing: null
 nothingthing:
 emptystring: ""
 nullstring: "null"
+datething: 2022-09-23
+timestampthing: 2022-09-24T14:13:12-7:30
         """
 
         # Note that true nulls are translated as "\x00" (hexadecimal NULL
         # control-characters).
-        results = ["6", "6.8", "yes", "no", "True", "False", "\x00", "\x00", "", "null"]
+        results = ["6", "6.8", "yes", "no", "True", "False", "\x00", "\x00", "", "null", "2022-09-23", "2022-09-24T14:13:12-07:30"]
 
         yaml_file = create_temp_yaml_file(tmp_path_factory, content)
         result = script_runner.run(self.command, "--query=*", yaml_file)

--- a/tests/test_common_nodes.py
+++ b/tests/test_common_nodes.py
@@ -1,6 +1,24 @@
 import pytest
+from datetime import date, datetime
+from types import SimpleNamespace
 
-import ruamel.yaml as ry
+from ruamel.yaml.comments import CommentedSeq, CommentedMap, TaggedScalar
+from ruamel.yaml.scalarstring import PlainScalarString
+from ruamel.yaml.scalarbool import ScalarBoolean
+from ruamel.yaml.scalarfloat import ScalarFloat
+from ruamel.yaml.scalarint import ScalarInt
+from ruamel.yaml import version_info as ryversion
+if ryversion < (0, 17, 22):                   # pragma: no cover
+    from yamlpath.patches.timestamp import (
+        AnchoredTimeStamp,
+        AnchoredDate,
+    )  # type: ignore
+else:                                         # pragma: no cover
+    # Temporarily fool MYPY into resolving the future-case imports
+    from ruamel.yaml.timestamp import TimeStamp as AnchoredTimeStamp
+    AnchoredDate = AnchoredTimeStamp
+    #from ruamel.yaml.timestamp import AnchoredTimeStamp
+    # From whence shall come AnchoredDate?
 
 from yamlpath.enums import YAMLValueFormats
 from yamlpath.common import Nodes
@@ -18,7 +36,7 @@ class Test_common_nodes():
         assert "[]" == Nodes.make_new_node("", "[]", YAMLValueFormats.DEFAULT)
 
     def test_anchored_string(self):
-        node = ry.scalarstring.PlainScalarString("value")
+        node = PlainScalarString("value")
         node.yaml_set_anchor("anchored")
         new_node = Nodes.make_new_node(node, "new", YAMLValueFormats.DEFAULT)
         assert new_node.anchor.value == node.anchor.value
@@ -29,15 +47,15 @@ class Test_common_nodes():
     ###
     def test_tag_map(self):
         new_tag = "!something"
-        old_node = ry.comments.CommentedMap({"key": "value"})
+        old_node = CommentedMap({"key": "value"})
         new_node = Nodes.apply_yaml_tag(old_node, new_tag)
         assert new_node.tag.value == new_tag
 
     def test_update_tag(self):
         old_tag = "!tagged"
         new_tag = "!changed"
-        old_node = ry.scalarstring.PlainScalarString("tagged value")
-        tagged_node = ry.comments.TaggedScalar(old_node, tag=old_tag)
+        old_node = PlainScalarString("tagged value")
+        tagged_node = TaggedScalar(old_node, tag=old_tag)
         new_node = Nodes.apply_yaml_tag(tagged_node, new_tag)
         assert new_node.tag.value == new_tag
         assert new_node.value == old_node
@@ -45,8 +63,8 @@ class Test_common_nodes():
     def test_delete_tag(self):
         old_tag = "!tagged"
         new_tag = ""
-        old_node = ry.scalarstring.PlainScalarString("tagged value")
-        tagged_node = ry.comments.TaggedScalar(old_node, tag=old_tag)
+        old_node = PlainScalarString("tagged value")
+        tagged_node = TaggedScalar(old_node, tag=old_tag)
         new_node = Nodes.apply_yaml_tag(tagged_node, new_tag)
         assert not hasattr(new_node, "tag")
         assert new_node == old_node
@@ -73,3 +91,21 @@ class Test_common_nodes():
             {"key": "value"},
             None
         ])
+
+
+    ###
+    # wrap_type
+    ###
+    @pytest.mark.parametrize("value,checktype", [
+        ([], CommentedSeq),
+        ({}, CommentedMap),
+        ("", PlainScalarString),
+        (1, ScalarInt),
+        (1.1, ScalarFloat),
+        (True, ScalarBoolean),
+        (date(2022, 8, 2), AnchoredDate),
+        (datetime(2022, 8, 2, 13, 22, 31), AnchoredTimeStamp),
+        (SimpleNamespace(), SimpleNamespace),
+    ])
+    def test_wrap_type(self, value, checktype):
+        assert isinstance(Nodes.wrap_type(value), checktype)

--- a/tests/test_enums_yamlvalueformats.py
+++ b/tests/test_enums_yamlvalueformats.py
@@ -1,4 +1,5 @@
 import pytest
+from datetime import datetime, date
 
 from ruamel.yaml.scalarstring import (
     PlainScalarString,
@@ -10,6 +11,15 @@ from ruamel.yaml.scalarstring import (
 from ruamel.yaml.scalarbool import ScalarBoolean
 from ruamel.yaml.scalarfloat import ScalarFloat
 from ruamel.yaml.scalarint import ScalarInt
+from ruamel.yaml import version_info as ryversion
+if ryversion < (0, 17, 22):                   # pragma: no cover
+    from yamlpath.patches.timestamp import (
+        AnchoredTimeStamp,
+    )  # type: ignore
+else:
+    # Temporarily fool MYPY into resolving the future-case imports
+    from ruamel.yaml.timestamp import TimeStamp as AnchoredTimeStamp
+    #from ruamel.yaml.timestamp import AnchoredTimeStamp
 
 from yamlpath.enums import YAMLValueFormats
 
@@ -20,6 +30,7 @@ class Test_enums_YAMLValueFormats():
 		assert YAMLValueFormats.get_names() == [
 			"BARE",
 			"BOOLEAN",
+			"DATE",
 			"DEFAULT",
 			"DQUOTE",
 			"FLOAT",
@@ -27,11 +38,13 @@ class Test_enums_YAMLValueFormats():
 			"INT",
 			"LITERAL",
 			"SQUOTE",
+			"TIMESTAMP",
 		]
 
 	@pytest.mark.parametrize("input,output", [
 		("BARE", YAMLValueFormats.BARE),
 		("BOOLEAN", YAMLValueFormats.BOOLEAN),
+		("DATE", YAMLValueFormats.DATE),
 		("DEFAULT", YAMLValueFormats.DEFAULT),
 		("DQUOTE", YAMLValueFormats.DQUOTE),
 		("FLOAT", YAMLValueFormats.FLOAT),
@@ -39,6 +52,7 @@ class Test_enums_YAMLValueFormats():
 		("INT", YAMLValueFormats.INT),
 		("LITERAL", YAMLValueFormats.LITERAL),
 		("SQUOTE", YAMLValueFormats.SQUOTE),
+		("TIMESTAMP", YAMLValueFormats.TIMESTAMP),
 	])
 	def test_from_str(self, input, output):
 		assert output == YAMLValueFormats.from_str(input)
@@ -50,12 +64,14 @@ class Test_enums_YAMLValueFormats():
 	@pytest.mark.parametrize("input,output", [
 		(FoldedScalarString(""), YAMLValueFormats.FOLDED),
 		(LiteralScalarString(""), YAMLValueFormats.LITERAL),
+		(date(2022, 9, 24), YAMLValueFormats.DATE),
 		(DoubleQuotedScalarString(''), YAMLValueFormats.DQUOTE),
 		(SingleQuotedScalarString(""), YAMLValueFormats.SQUOTE),
 		(PlainScalarString(""), YAMLValueFormats.BARE),
 		(ScalarBoolean(False), YAMLValueFormats.BOOLEAN),
 		(ScalarFloat(1.01), YAMLValueFormats.FLOAT),
 		(ScalarInt(10), YAMLValueFormats.INT),
+		(AnchoredTimeStamp(2022, 9, 24, 7, 42, 38), YAMLValueFormats.TIMESTAMP),
 		(None, YAMLValueFormats.DEFAULT),
 	])
 	def test_from_node(self, input, output):

--- a/tests/test_func.py
+++ b/tests/test_func.py
@@ -9,7 +9,6 @@ from ruamel.yaml.scalarfloat import ScalarFloat
 from ruamel.yaml.scalarint import ScalarInt
 
 from yamlpath.enums import AnchorMatches, PathSearchMethods, YAMLValueFormats
-from yamlpath.types import PathAttributes
 from yamlpath.path import SearchTerms
 from yamlpath import YAMLPath
 from yamlpath.func import (
@@ -31,7 +30,7 @@ from yamlpath.func import (
     wrap_type,
 )
 
-from tests.conftest import create_temp_yaml_file, quiet_logger
+from tests.conftest import create_temp_yaml_file
 
 
 @pytest.fixture

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,22 +1,29 @@
 import pytest
-from datetime import date
+from datetime import date, datetime
 from types import SimpleNamespace
 
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import TaggedScalar
+from ruamel.yaml import version_info as ryversion
+if ryversion < (0, 17, 22):                   # pragma: no cover
+    from yamlpath.patches.timestamp import (
+        AnchoredTimeStamp,
+        AnchoredDate,
+    )  # type: ignore
+else:
+    from ruamel.yaml.timestamp import AnchoredTimeStamp
+    # From whence comes AnchoredDate?
 
 from yamlpath.func import unwrap_node_coords
 from yamlpath.exceptions import YAMLPathException
 from yamlpath.enums import (
     PathSeperators,
     PathSegmentTypes,
-    PathSearchMethods,
     YAMLValueFormats,
 )
 from yamlpath.path import SearchTerms
 from yamlpath.wrappers import ConsolePrinter
 from yamlpath import YAMLPath, Processor
-from tests.conftest import quiet_logger
 
 
 class Test_Processor():
@@ -80,7 +87,7 @@ class Test_Processor():
         ("/**/Hey*", ["Hey, Number Two!"], True, None),
         ("lots_of_names.**.name", ["Name 1-1", "Name 2-1", "Name 3-1", "Name 4-1", "Name 4-2", "Name 4-3", "Name 4-4"], True, None),
         ("/array_of_hashes/**", [1, "one", 2, "two"], True, None),
-        ("products_hash.*[dimensions.weight==4].(availability.start.date)+(availability.stop.date)", [[date(2020, 8, 1), date(2020, 9, 25)], [date(2020, 1, 1), date(2020, 1, 1)]], True, None),
+        ("products_hash.*[dimensions.weight==4].(availability.start.date)+(availability.stop.date)", [[AnchoredDate(2020, 8, 1), AnchoredDate(2020, 9, 25)], [AnchoredDate(2020, 1, 1), AnchoredDate(2020, 1, 1)]], True, None),
         ("products_array[dimensions.weight==4].product", ["doohickey", "widget"], True, None),
         ("(products_hash.*.dimensions.weight)[max()][parent(2)].dimensions.weight", [10], True, None),
         ("/Locations/*/*", ["ny", "bstn"], True, None),
@@ -491,6 +498,122 @@ null_value:
             assert changed_value == value
             matchtally += 1
         assert matchtally == tally
+
+    @pytest.mark.parametrize("yamlpath,value,compare,tally,mustexist,vformat,pathsep", [
+        ("/datetimes/date",
+          date(2022, 8, 2),
+          AnchoredDate(2022, 8, 2),
+          1,
+          True,
+          YAMLValueFormats.DATE,
+          PathSeperators.FSLASH,
+        ),
+        ("datetimes.date",
+          '2022-08-02',
+          AnchoredDate(2022, 8, 2),
+          1,
+          True,
+          YAMLValueFormats.DATE,
+          PathSeperators.DOT,
+        ),
+        ("datetimes.timestamp",
+          datetime(2022, 8, 2, 13, 22, 31),
+          AnchoredTimeStamp(2022, 8, 2, 13, 22, 31),
+          1,
+          True,
+          YAMLValueFormats.TIMESTAMP,
+          PathSeperators.DOT,
+        ),
+        ("/datetimes/timestamp",
+          '2022-08-02T13:22:31',
+          AnchoredTimeStamp(2022, 8, 2, 13, 22, 31),
+          1,
+          True,
+          YAMLValueFormats.TIMESTAMP,
+          PathSeperators.FSLASH,
+        ),
+        ("aliases[&date]",
+          '2022-08-02',
+          AnchoredDate(2022, 8, 2),
+          1,
+          True,
+          YAMLValueFormats.DATE,
+          PathSeperators.DOT,
+        ),
+        ("aliases[&timestamp]",
+          datetime(2022, 8, 2, 13, 22, 31),
+          AnchoredTimeStamp(2022, 8, 2, 13, 22, 31),
+          1,
+          True,
+          YAMLValueFormats.TIMESTAMP,
+          PathSeperators.DOT,
+        ),
+    ])
+    def test_set_datetimes(self, quiet_logger, yamlpath, value, compare, tally, mustexist, vformat, pathsep):
+        yamldata = """---
+aliases:
+  - &date 2022-02-21
+  - &timestamp 2022-11-20T15:14:13
+datetimes:
+  date: 2022-09-23
+  timestamp: 2022-09-24T01:02:03.04000
+reused:
+  date: *date
+  timestamp: *timestamp
+"""
+        yaml = YAML()
+        data = yaml.load(yamldata)
+        processor = Processor(quiet_logger, data)
+        processor.set_value(yamlpath, value, mustexist=mustexist, value_format=vformat, pathsep=pathsep)
+        matchtally = 0
+        for node in processor.get_nodes(yamlpath, mustexist=mustexist):
+            changed_value = unwrap_node_coords(node)
+            if isinstance(changed_value, list):
+                compare_idx = 0
+                for result in changed_value:
+                    assert result == compare[compare_idx]
+                    compare_idx += 1
+                    matchtally += 1
+                continue
+            assert changed_value == compare
+            matchtally += 1
+        assert matchtally == tally
+
+    @pytest.mark.parametrize("yamlpath,value,vformat,exmsg", [
+        ("/datetimes/date",
+          "2022.9.24",
+          YAMLValueFormats.DATE,
+          "not a YAML-compatible ISO8601 date"
+        ),
+        ("/datetimes/date",
+          "2022-90-24",
+          YAMLValueFormats.DATE,
+          "cannot be cast to an ISO8601 date"
+        ),
+        ("/datetimes/timestamp",
+          "2022-9-24 @ 7:41am",
+          YAMLValueFormats.TIMESTAMP,
+          "not a YAML-compatible ISO8601 timestamp"
+        ),
+        ("/datetimes/timestamp",
+          "2022-90-24T07:41:00",
+          YAMLValueFormats.TIMESTAMP,
+          "cannot be cast to an ISO8601 timestamp"
+        ),
+    ])
+    def test_cannot_set_impossible_datetimes(self, quiet_logger, yamlpath, value, vformat, exmsg):
+        yamldata = """---
+datetimes:
+  date: 2022-09-23
+  timestamp: 2022-09-24T01:02:03.04000
+"""
+        yaml = YAML()
+        data = yaml.load(yamldata)
+        processor = Processor(quiet_logger, data)
+
+        with pytest.raises(YAMLPathException) as ex:
+            processor.set_value(yamlpath, value, value_format=vformat)
+        assert -1 < str(ex.value).find(exmsg)
 
     def test_cannot_set_nonexistent_required_node_error(self, quiet_logger):
         yamldata = """---
@@ -973,9 +1096,11 @@ nullthing: null
 nothingthing:
 emptystring: ""
 nullstring: "null"
+datething: 2022-09-24
+timestampthing: 2022-09-24T15:24:32
         """
 
-        results = [6, 6.8, "yes", "no", True, False, None, None, "", "null"]
+        results = [6, 6.8, "yes", "no", True, False, None, None, "", "null", AnchoredDate(2022, 9, 24), AnchoredTimeStamp(2022, 9, 24, 15, 24, 32)]
 
         yaml = YAML()
         data = yaml.load(yamldata)

--- a/tests/test_wrappers_consoleprinter.py
+++ b/tests/test_wrappers_consoleprinter.py
@@ -4,6 +4,18 @@ from types import SimpleNamespace
 
 from ruamel.yaml.comments import CommentedMap, CommentedSeq, CommentedSet, TaggedScalar
 from ruamel.yaml.scalarstring import PlainScalarString, FoldedScalarString
+from ruamel.yaml import version_info as ryversion
+if ryversion < (0, 17, 22):                   # pragma: no cover
+    from yamlpath.patches.timestamp import (
+        AnchoredTimeStamp,
+        AnchoredDate,
+    )  # type: ignore
+else:                                         # pragma: no cover
+    # Temporarily fool MYPY into resolving the future-case imports
+    from ruamel.yaml.timestamp import TimeStamp as AnchoredTimeStamp
+    AnchoredDate = AnchoredTimeStamp
+    #from ruamel.yaml.timestamp import AnchoredTimeStamp
+    # From whence shall come AnchoredDate?
 
 from yamlpath.enums import PathSegmentTypes
 from yamlpath.wrappers import NodeCoords, ConsolePrinter
@@ -73,6 +85,13 @@ class Test_wrappers_ConsolePrinter():
         assert "\n".join([
             "DEBUG:  [0]test<class 'str'>",
             "DEBUG:  [1](&Anchor)TestVal<class 'ruamel.yaml.scalarstring.PlainScalarString'>",
+        ]) + "\n" == console.out
+
+        logger.debug({"date": AnchoredDate(2022, 9, 23), "timestamp": AnchoredTimeStamp(2022, 9, 25, 1, 2, 3, 40000)})
+        console = capsys.readouterr()
+        assert "\n".join([
+            "DEBUG:  [date]2022-09-23<class 'yamlpath.patches.timestamp.AnchoredDate'>",
+            "DEBUG:  [timestamp]2022-09-25T01:02:03.040000<class 'yamlpath.patches.timestamp.AnchoredTimeStamp'>",
         ]) + "\n" == console.out
 
         logger.debug({"ichi": 1, anchoredkey: anchoredval})

--- a/yamlpath/__init__.py
+++ b/yamlpath/__init__.py
@@ -1,6 +1,6 @@
 """Core YAML Path classes."""
 # Establish the version number common to all components
-__version__ = "3.6.5"
+__version__ = "3.6.6"
 
 from yamlpath.yamlpath import YAMLPath
 from yamlpath.processor import Processor

--- a/yamlpath/commands/yaml_get.py
+++ b/yamlpath/commands/yaml_get.py
@@ -15,9 +15,22 @@ from os import access, R_OK
 from os.path import isfile
 
 from ruamel.yaml.comments import CommentedSet
+# pylint: disable=wrong-import-position,ungrouped-imports
+from ruamel.yaml import version_info as ryversion
+if ryversion < (0, 17, 22):                   # pragma: no cover
+    from yamlpath.patches.timestamp import (
+        AnchoredTimeStamp,
+        AnchoredDate,
+    )  # type: ignore
+else:                                         # pragma: no cover
+    # Temporarily fool MYPY into resolving the future-case imports
+    from ruamel.yaml.timestamp import TimeStamp as AnchoredTimeStamp
+    AnchoredDate = AnchoredTimeStamp
+    #from ruamel.yaml.timestamp import AnchoredTimeStamp
+    # From whence shall come AnchoredDate?
 
 from yamlpath import __version__ as YAMLPATH_VERSION
-from yamlpath.common import Parsers
+from yamlpath.common import Parsers, Nodes
 from yamlpath import YAMLPath
 from yamlpath.exceptions import YAMLPathException
 from yamlpath.eyaml.exceptions import EYAMLCommandException
@@ -26,6 +39,7 @@ from yamlpath.wrappers import NodeCoords
 from yamlpath.eyaml import EYAMLProcessor
 
 from yamlpath.wrappers import ConsolePrinter
+# pylint: enable=wrong-import-position,ungrouped-imports
 
 def processcli():
     """Process command-line arguments."""
@@ -193,6 +207,10 @@ def main():
             else:
                 if node is None:
                     node = "\x00"
+                elif isinstance(node, AnchoredDate):
+                    node = node.date().isoformat()
+                elif isinstance(node, AnchoredTimeStamp):
+                    node = Nodes.get_timestamp_with_tzinfo(node).isoformat()
                 print("{}".format(str(node).replace("\n", r"\n")))
     except RecursionError:
         log.critical(

--- a/yamlpath/common/nodes.py
+++ b/yamlpath/common/nodes.py
@@ -4,8 +4,11 @@ Implement Nodes, a static library of generally-useful code for data nodes.
 Copyright 2020 William W. Kimball, Jr. MBA MSIS
 """
 import re
+from datetime import datetime, date, timedelta, timezone
 from ast import literal_eval
 from typing import Any
+
+from dateutil import parser
 
 from ruamel.yaml.comments import CommentedSeq, CommentedMap, TaggedScalar
 from ruamel.yaml.scalarbool import ScalarBoolean
@@ -18,6 +21,19 @@ from ruamel.yaml.scalarstring import (
     FoldedScalarString,
     LiteralScalarString,
 )
+# pylint: disable=wrong-import-position,ungrouped-imports
+from ruamel.yaml import version_info as ryversion
+if ryversion < (0, 17, 22):                   # pragma: no cover
+    from yamlpath.patches.timestamp import (
+        AnchoredTimeStamp,
+        AnchoredDate,
+    )  # type: ignore
+else:                                         # pragma: no cover
+    # Temporarily fool MYPY into resolving the future-case imports
+    from ruamel.yaml.timestamp import TimeStamp as AnchoredTimeStamp
+    AnchoredDate = AnchoredTimeStamp
+    #from ruamel.yaml.timestamp import AnchoredTimeStamp
+    # From whence shall come AnchoredDate?
 
 from yamlpath.enums import (
     PathSegmentTypes,
@@ -25,6 +41,7 @@ from yamlpath.enums import (
 )
 from yamlpath.wrappers import NodeCoords
 from yamlpath import YAMLPath
+# pylint: enable=wrong-import-position,ungrouped-imports
 
 
 class Nodes:
@@ -57,10 +74,10 @@ class Nodes:
         - `ValueError' when the new value is not numeric and value_format
         requires it to be so
         """
-        new_node = None
-        new_type = type(source_node)
-        new_value = value
-        valform = YAMLValueFormats.DEFAULT
+        new_node: Any = None
+        new_type: Any = type(source_node)
+        new_value: Any = value
+        valform: YAMLValueFormats = YAMLValueFormats.DEFAULT
 
         if isinstance(value_format, YAMLValueFormats):
             valform = value_format
@@ -139,6 +156,79 @@ class Nodes:
                     + " cast to an integer number.")
                     .format(valform, value)
                 ) from wrap_ex
+        elif valform == YAMLValueFormats.DATE:
+            new_type = AnchoredDate
+
+            if isinstance(value, (AnchoredDate, date, datetime)):
+                new_value = value
+            else:
+                # Enforce matches against http://yaml.org/type/timestamp.html
+                yaml_spec_re = re.compile(r"""(?x)
+                    ^
+                    [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] # (ymd)
+                    $""")
+                dt_matches = yaml_spec_re.match(value)
+                if not dt_matches:
+                    raise ValueError(
+                        f"The requested value format is {valform}, but"
+                        + f" '{value}' is not a YAML-compatible ISO8601 date"
+                        + " per http://yaml.org/type/timestamp.html")
+
+                try:
+                    new_value = parser.parse(value)
+                except ValueError as wrap_ex:
+                    raise ValueError(
+                        f"The requested value format is {valform}, but "
+                        + f" {value}' cannot be cast to an ISO8601 date."
+                    ) from wrap_ex
+
+            anchor_val = None
+            if hasattr(source_node, "anchor"):
+                anchor_val = source_node.anchor.value
+
+            new_node = Nodes.make_date_node(new_value, anchor_val)
+        elif valform == YAMLValueFormats.TIMESTAMP:
+            new_type = AnchoredTimeStamp
+            t_sep = ' '
+
+            if isinstance(value, (datetime, AnchoredTimeStamp)):
+                new_value = value
+            else:
+                # Enforce matches against http://yaml.org/type/timestamp.html
+                yaml_spec_re = re.compile(r"""(?x)
+                    ^
+                    [0-9][0-9][0-9][0-9] # (year)
+                    -[0-9][0-9]? # (month)
+                    -[0-9][0-9]? # (day)
+                    ([Tt]|[ \t]+)[0-9][0-9]? # (hour)
+                    :[0-9][0-9] # (minute)
+                    :[0-9][0-9] # (second)
+                    (\.[0-9]*)? # (fraction)
+                    (([ \t]*)Z|[-+][0-9][0-9]?(:[0-9][0-9])?)? # (time zone)
+                    $""")
+                dt_matches = yaml_spec_re.match(value)
+                if not dt_matches:
+                    raise ValueError(
+                        f"The requested value format is {valform}, but"
+                        + f" '{value}' is not a YAML-compatible ISO8601"
+                        + " timestamp per http://yaml.org/type/timestamp.html")
+
+                t_sep = dt_matches.group(1)
+
+                try:
+                    new_value = parser.parse(value)
+                except ValueError as wrap_ex:
+                    raise ValueError(
+                        f"The requested value format is {valform}, but"
+                        + f" '{value}' cannot be cast to an ISO8601 timestamp."
+                    ) from wrap_ex
+
+            anchor_val = None
+            if hasattr(source_node, "anchor"):
+                anchor_val = source_node.anchor.value
+
+            new_node = Nodes.make_timestamp_node(
+                new_value, t_sep, anchor_val)
         else:
             # Punt to whatever the best Scalar type may be
             try:
@@ -169,6 +259,85 @@ class Nodes:
         # Apply a custom tag, if provided
         if "tag" in kwargs:
             new_node = Nodes.apply_yaml_tag(new_node, kwargs.pop("tag"))
+
+        return new_node
+
+    @staticmethod
+    def make_date_node(value: date, anchor: str = None) -> AnchoredDate:
+        r"""
+        Create a new AnchoredDate data node from a bare date.
+
+        An optional anchor may be attached.
+
+        Parameters:
+        1. value (date) The bare date to wrap.
+        2. anchor (str) OPTIONAL anchor to add.
+
+        Returns: (AnchoredDate) The new node
+        """
+        if anchor is None:
+            new_node = AnchoredDate(
+                value.year
+                , value.month
+                , value.day
+            )
+        else:
+            new_node = AnchoredDate(
+                value.year
+                , value.month
+                , value.day
+                , anchor=anchor
+            )
+
+        return new_node
+
+    @staticmethod
+    def make_timestamp_node(
+        value: datetime, t_separator: str, anchor: str = None
+    ) -> AnchoredTimeStamp:
+        r"""
+        Create a new AnchoredTimeStamp data node from a bare datetime.
+
+        An optional anchor may be attached.
+
+        Parameters:
+        1. value (datetime) The bare datetime to wrap.
+        2. t_separator (str) One of [Tt\s] to separate date from time
+        3. anchor (str) OPTIONAL anchor to add.
+
+        Returns: (AnchoredTimeStamp) The new node
+        """
+        if anchor is None:
+            new_node = AnchoredTimeStamp(
+                value.year
+                , value.month
+                , value.day
+                , value.hour
+                , value.minute
+                , value.second
+                , value.microsecond
+                , value.tzinfo
+            )
+        else:
+            new_node = AnchoredTimeStamp(
+                value.year
+                , value.month
+                , value.day
+                , value.hour
+                , value.minute
+                , value.second
+                , value.microsecond
+                , value.tzinfo
+                , anchor=anchor
+            )
+
+        # Add a T separator only when set
+        if t_separator in ['T', 't']:
+            # Ignore W0212 here because there is literally no other way to tell
+            # ruamel.yaml to preserve the T separator for this timestamp at the
+            # time of this writing.  This code is indeed therefore fragile.
+            # pylint: disable=protected-access
+            new_node._yaml['t'] = t_separator
 
         return new_node
 
@@ -268,6 +437,14 @@ class Nodes:
             wrapped_value = Nodes.make_float_node(ast_value)
         elif typ is bool:
             wrapped_value = ScalarBoolean(bool(value))
+        elif typ is date:
+            wrapped_value = AnchoredDate(
+                value.year, value.month, value.day)
+        elif typ is datetime:
+            wrapped_value = AnchoredTimeStamp(
+                value.year, value.month, value.day,
+                value.hour, value.minute, value.second, value.microsecond,
+                value.tzinfo)
 
         return wrapped_value
 
@@ -481,3 +658,45 @@ class Nodes:
         except SyntaxError:
             typed_value = value
         return typed_value
+
+    @staticmethod
+    def get_timestamp_with_tzinfo(data: AnchoredTimeStamp) -> datetime:
+        """
+        Get an AnchoredTimeStamp with time-zone info correctly applied.
+
+        For whatever reason, ruamel.yaml hides time-zone data in a private
+        dict rather than as a manifest property of the wrapped datetime value.
+        Doing so causes the datetime value to be pre-calculated when emitted,
+        with the time-zone delta applied to the original value.  The net effect
+        is users get a different value out than they put in.  This method
+        rewinds the pre-calculation and combines the time-zone with the
+        original data as befits a complete datetime value.
+
+        Parameters:
+        1. value (AnchoredTimeStamp) the value to correct
+
+        Returns:  (datetime) time-zone aware non-pre-calculated value
+        """
+        # As stated in the method comments, ruamel.yaml hides the time-zone
+        # details in a private dict after forcibly normalizing the datetime;
+        # there is no public accessor for this.  Also ignoring the mypy type
+        # check on the various returns because ruamel.yaml defines TimeStamp
+        # as an 'Any' type rather than a 'TimeStamp' or even its superclass of
+        # 'datetime'.  It is perfectly accurate to assert that this method is
+        # correctly returning a 'datetime' despite the ruamel.yaml type
+        # annotation error.
+        # pylint: disable=protected-access
+        tzinfo_raw = (data._yaml['tz']
+                        if hasattr(data, "_yaml") and 'tz' in data._yaml
+                        else None)
+        if tzinfo_raw:
+            tzre = re.compile(r'([+\-]?)(\d{1,2}):?(\d{2})')
+            tzmatches = tzre.match(tzinfo_raw)
+            if tzmatches:
+                sign_mark, hours, minutes = tzmatches.groups()
+                sign = -1 if sign_mark == '-' else 1
+                tdelta = timedelta(hours=int(hours), minutes=int(minutes))
+                tzinfo = timezone(sign * tdelta)
+                data = (data + tdelta * sign).replace(
+                    tzinfo=tzinfo)
+        return data # type: ignore

--- a/yamlpath/patches/timestamp.py
+++ b/yamlpath/patches/timestamp.py
@@ -1,0 +1,134 @@
+# pylint: skip-file
+# type: ignore
+"""
+Fix missing anchors from timestamp and date nodes.
+
+Source: https://sourceforge.net/p/ruamel-yaml/tickets/440/
+Copyright 2022 Anthon van der Neut
+"""
+import ruamel.yaml
+Anchor = ruamel.yaml.anchor.Anchor
+TimeStamp = ruamel.yaml.timestamp.TimeStamp
+
+from typing import Any, Dict, Union  # NOQA
+import datetime
+import copy
+
+
+if not hasattr(TimeStamp, 'anchor'):
+
+    class AnchoredTimeStamp(TimeStamp):
+        """Extend TimeStamp to track YAML Anchors."""
+
+        def __init__(self, *args: Any, **kw: Any) -> None:
+            """Initialize a new instance."""
+            self._yaml: Dict[Any, Any] = dict(t=False, tz=None, delta=0)
+
+        def __new__(cls, *args: Any, **kw: Any) -> Any:  # datetime is immutable
+            """Create a new, immutable instance."""
+            anchor = kw.pop('anchor', None)
+            ts = TimeStamp.__new__(cls, *args, **kw)
+            if anchor is not None:
+                ts.yaml_set_anchor(anchor, always_dump=True)
+            return ts
+
+        def __deepcopy__(self, memo: Any) -> Any:
+            """Deeply copy this instance to another."""
+            ts = AnchoredTimeStamp(self.year, self.month, self.day, self.hour, self.minute, self.second)
+            ts._yaml = copy.deepcopy(self._yaml)
+            return ts
+
+        @property
+        def anchor(self) -> Any:
+            """Access the YAML Anchor."""
+            if not hasattr(self, Anchor.attrib):
+                setattr(self, Anchor.attrib, Anchor())
+            return getattr(self, Anchor.attrib)
+
+        def yaml_anchor(self, any: bool = False) -> Any:
+            """Get the YAML Anchor."""
+            if not hasattr(self, Anchor.attrib):
+                return None
+            if any or self.anchor.always_dump:
+                return self.anchor
+            return None
+
+        def yaml_set_anchor(self, value: Any, always_dump: bool = False) -> None:
+            """Set the YAML Anchor."""
+            self.anchor.value = value
+            self.anchor.always_dump = always_dump
+
+
+    class AnchoredDate(AnchoredTimeStamp):
+        """Define AnchoredDate."""
+
+        pass
+
+
+    def construct_anchored_timestamp(
+        self, node: Any, values: Any = None
+    ) -> Union[AnchoredTimeStamp, AnchoredDate]:
+        """Construct an AnchoredTimeStamp."""
+        try:
+            match = self.timestamp_regexp.match(node.value)
+        except TypeError:
+            match = None
+        if match is None:
+            raise ConstructorError(
+                None,
+                None,
+                f'failed to construct timestamp from "{node.value}"',
+                node.start_mark,
+            )
+        values = match.groupdict()
+        dd = ruamel.yaml.util.create_timestamp(**values)  # this has delta applied
+        delta = None
+        if values['tz_sign']:
+            tz_hour = int(values['tz_hour'])
+            minutes = values['tz_minute']
+            tz_minute = int(minutes) if minutes else 0
+            delta = datetime.timedelta(hours=tz_hour, minutes=tz_minute)
+            if values['tz_sign'] == '-':
+                delta = -delta
+        if isinstance(dd, datetime.datetime):
+            data = AnchoredTimeStamp(
+                dd.year, dd.month, dd.day, dd.hour, dd.minute, dd.second, dd.microsecond, anchor=node.anchor
+            )
+        else:
+            data = AnchoredDate(dd.year, dd.month, dd.day, 0, 0, 0, 0, anchor=node.anchor)
+            return data
+        if delta:
+            data._yaml['delta'] = delta
+            tz = values['tz_sign'] + values['tz_hour']
+            if values['tz_minute']:
+                tz += ':' + values['tz_minute']
+            data._yaml['tz'] = tz
+        else:
+            if values['tz']:  # no delta
+                data._yaml['tz'] = values['tz']
+        if values['t']:
+            data._yaml['t'] = True
+        return data
+
+    ruamel.yaml.constructor.RoundTripConstructor.add_constructor('tag:yaml.org,2002:timestamp', construct_anchored_timestamp)
+
+    def represent_anchored_timestamp(self, data: Any):
+        """Render an AnchoredTimeStamp."""
+        try:
+            anchor = data.yaml_anchor()
+        except AttributeError:
+            anchor = None
+        inter = 'T' if data._yaml['t'] else ' '
+        _yaml = data._yaml
+        if _yaml['delta']:
+            data += _yaml['delta']
+        if isinstance(data, AnchoredDate):
+            value = data.date().isoformat()
+        else:
+            value = data.isoformat(inter)
+        if _yaml['tz']:
+            value += _yaml['tz']
+        return self.represent_scalar('tag:yaml.org,2002:timestamp', value, anchor=anchor)
+
+    ruamel.yaml.representer.RoundTripRepresenter.add_representer(AnchoredTimeStamp, represent_anchored_timestamp)
+    ruamel.yaml.representer.RoundTripRepresenter.add_representer(AnchoredDate, represent_anchored_timestamp)


### PR DESCRIPTION
3.6.6
Enhancements:
* Support ruamel.yaml up to version 0.17.21.

Bug Fixes:
* YAML timestamp values could not be created via yamlpath tools or its library,
  per http://yaml.org/type/timestamp.html.
  Thanks again go to https://github.com/AndydeCleyre!
  * CAUTION 1:  ruamel.yaml seems to force all timestamps to UTC while it loads
    YAML/JSON/Compatible data.  So, when the timestamp value contains time-zone
    data, it will be stripped off after it is applied to the timestamp value.
    The yamlpath library reverses this when emitting the affected values but if
    you attempt to load the timestamp values directly in the DOM, you'll end up
    with the UTC-converted value, stripped of any time-zone specification.  If
    you need the original, unmodified data as a time-zone aware
    datetime.datetime value, pass it through the helper method,
    Nodes.get_timestamp_with_tzinfo(data: AnchoredTimeStamp).
  * CAUTION 2:  In order to support timestamp parsing, this project now depends
    on the python-dateutil library.  Be sure to install it!
