### PR TITLE
Exclude tests from being installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     author_email="github-yamlpath@kimballstuff.com",
     license="ISC",
     keywords="yaml eyaml json yaml-path diff merge",
-    packages=find_packages(),
+    packages=find_packages(exclude=["tests"]),
     entry_points={
         "console_scripts": [
             "eyaml-rotate-keys = yamlpath.commands.eyaml_rotate_keys:main",


### PR DESCRIPTION
Do not install `tests` as a top-level package -- such a package name is bound to collide with other packages, and for this reason no package should be installing files there.