### PR TITLE
Fix #206

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04 # Use ubuntu-latest when https://github.com/actions/setup-python/issues/544 is fixed
     strategy:
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']

--- a/.github/workflows/python-publish-to-prod-pypi.yml
+++ b/.github/workflows/python-publish-to-prod-pypi.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   publish:
     name: Publish to Production PyPI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04 # Use ubuntu-latest when https://github.com/actions/setup-python/issues/544 is fixed
     environment: 'PyPI:  Production'
 
     steps:

--- a/.github/workflows/python-publish-to-test-pypi.yml
+++ b/.github/workflows/python-publish-to-test-pypi.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   validate:
     name: Code Quality Assessment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04 # Use ubuntu-latest when https://github.com/actions/setup-python/issues/544 is fixed
     strategy:
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']

--- a/CHANGES
+++ b/CHANGES
@@ -29,6 +29,10 @@ Bug Fixes:
   incorrectly spelled version of this enumeration is now deprecated and will be
   removed in a future release.  Thanks go entirely to
   https://github.com/AndydeCleyre for working so hard to submit this fix!
+* Processor.get_nodes would emit a nonobvious error message when mustexist is
+  left at its default value (False) and yaml_path contained ** or * segments.
+  Now, these segment types are excluded from generating "missing" nodes; only
+  nodes which exist can be matched by * and **.
 
 3.6.9:
 Enhancements:

--- a/yamlpath/processor.py
+++ b/yamlpath/processor.py
@@ -2412,10 +2412,14 @@ class Processor:
                 ):
                     yield node_coord
 
+            # Do not add arbitrary nodes that are based on searched or
+            # wildcards.  Such an outcome is unpredictable.
             if (
                     matched_nodes < 1
                     and segment_type is not PathSegmentTypes.SEARCH
                     and segment_type is not PathSegmentTypes.KEYWORD_SEARCH
+                    and segment_type is not PathSegmentTypes.MATCH_ALL
+                    and segment_type is not PathSegmentTypes.TRAVERSE
             ):
                 # Add the missing element
                 self.logger.debug(


### PR DESCRIPTION
As with search and keyword segments, also block wildcard segments from attempting to auto-generate "missing" document structure when `mustexist=False`.