### PR TITLE
Release 3.8.0

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,10 @@
 3.8.0
 Enhancements:
+* The yaml-set and yaml-merge command-line tools now support a new option:
+  --json-indent/-J.  This applies only to JSON output.  By default, JSON
+  documents are written/printed as single-line documents.  This new option
+  enables users to vertically expand JSON output with a specified indentation
+  size for nest levels.
 * Additional *YAMLPathExceptions have been added to increase the specificity of
   various error conditions.  You do not need to change any of your code as a
   result of this change; all new exceptions are subclasses of the original

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,30 @@
+3.8.0
+Enhancements:
+* Additional *YAMLPathExceptions have been added to increase the specificity of
+  various error conditions.  You do not need to change any of your code as a
+  result of this change; all new exceptions are subclasses of the original
+  YAMLPathException.  The new exceptions include:
+  * UnmatchedYAMLPathException:  No matching nodes
+  * DuplicateKeyYAMLPathException:  Duplicate key creation attempted
+  * TypeMismatchYAMLPathException:  Data Type mismatch
+  * BadAliasYAMLPathException:  Anchor/Alias/YMK error
+  * NoDocumentYAMLPathException:  Attempt to delete the entire document
+  * RecursionYAMLPathException:  Recursion nesting error
+* The Processor class now enables consumers to verify whether a YAMLPath would
+  resolve to at least one node in the present document.  The result is a simple
+  Boolean (True when the path resolves; False, otherwise).  The document is not
+  modified by this test.  See:  Processor.exists(yaml_path)
+
+Bug Fixes:
+* Pursuant to the addition of the intersection operator (&) added in 3.7.0, the
+  text of one of the YAMLPathExceptions has been updated:
+    Former:
+      Adjoining Collectors without an operator has no meaning; try + or -
+      between them, {yaml_path}
+    New:
+      Adjoining Collectors without an operator has no meaning; try +, -, or &
+      between them, {yaml_path}
+
 3.7.0
 Enhancements:
 * Support for Python 3.11 has been added.

--- a/tests/test_commands_yaml_merge.py
+++ b/tests/test_commands_yaml_merge.py
@@ -323,6 +323,70 @@ hash:
             filedat = fhnd.read()
         assert merged_yaml_content == filedat
 
+    def test_merge_two_across_multidoc_yaml_files_to_file_json_indented(self, script_runner, tmp_path, tmp_path_factory):
+        lhs_file = create_temp_yaml_file(tmp_path_factory, """---
+hash:
+  lhs_exclusive: LHS exclusive
+  merge_target: LHS original value
+...
+---
+hash:
+  lhs2_exclusive: LHS2 exclusive
+  merge2_target: LHS2 original value
+""")
+        rhs_file = create_temp_yaml_file(tmp_path_factory, """---
+hash:
+  rhs_exclusive: RHS exclusive
+  merge_target: RHS override value
+...
+---
+hash:
+  rhs2_exclusive: RHS2 exclusive
+  merge_target: RHS2 override value
+  merge2_target: RHS2 2nd override value
+""")
+        merged_yaml_content = """{
+    "hash": {
+        "lhs_exclusive": "LHS exclusive",
+        "rhs_exclusive": "RHS exclusive",
+        "merge_target": "RHS override value"
+    }
+}
+{
+    "hash": {
+        "lhs2_exclusive": "LHS2 exclusive",
+        "merge2_target": "RHS2 2nd override value",
+        "rhs2_exclusive": "RHS2 exclusive",
+        "merge_target": "RHS2 override value"
+    }
+}
+"""
+
+        output_dir = tmp_path / "test_merge_two_across_multidoc_yaml_files_to_file_json_indented"
+        output_dir.mkdir()
+        output_file = output_dir / "output.json"
+
+        # DEBUG
+        # print("LHS File:  {}".format(lhs_file))
+        # print("RHS File:  {}".format(rhs_file))
+        # print("Output File:  {}".format(output_file))
+        # print("Expected Output:")
+        # print(merged_yaml_content)
+
+        result = script_runner.run(
+            self.command
+            , "--nostdin"
+            , "--output={}".format(output_file)
+            , "--multi-doc-mode=merge_across"
+            , "--json-indent=4"
+            , lhs_file
+            , rhs_file)
+        assert result.success, result.stderr
+
+        with open(output_file, 'r') as fhnd:
+            filedat = fhnd.read()
+        assert merged_yaml_content == filedat
+
     def test_merge_two_across_multidoc_yaml_files_to_stdout_json(self, script_runner, tmp_path, tmp_path_factory):
         lhs_file = create_temp_yaml_file(tmp_path_factory, """---
 hash:
@@ -365,6 +429,115 @@ hash:
             , "--nostdin"
             , "--multi-doc-mode=merge_across"
             , "--document-format=json"
+            , lhs_file
+            , rhs_file)
+        assert result.success, result.stderr
+        assert merged_yaml_content == result.stdout
+
+    def test_merge_two_across_multidoc_yaml_files_to_stdout_json_indented(self, script_runner, tmp_path, tmp_path_factory):
+        lhs_file = create_temp_yaml_file(tmp_path_factory, """---
+hash:
+  lhs_exclusive: LHS exclusive
+  merge_target: LHS original value
+...
+---
+hash:
+  lhs2_exclusive: LHS2 exclusive
+  merge2_target: LHS2 original value
+""")
+        rhs_file = create_temp_yaml_file(tmp_path_factory, """---
+hash:
+  rhs_exclusive: RHS exclusive
+  merge_target: RHS override value
+...
+---
+hash:
+  rhs2_exclusive: RHS2 exclusive
+  merge_target: RHS2 override value
+  merge2_target: RHS2 2nd override value
+""")
+        merged_yaml_content = """{
+    "hash": {
+        "lhs_exclusive": "LHS exclusive",
+        "rhs_exclusive": "RHS exclusive",
+        "merge_target": "RHS override value"
+    }
+}
+{
+    "hash": {
+        "lhs2_exclusive": "LHS2 exclusive",
+        "merge2_target": "RHS2 2nd override value",
+        "rhs2_exclusive": "RHS2 exclusive",
+        "merge_target": "RHS2 override value"
+    }
+}
+"""
+
+        output_dir = tmp_path / "test_merge_two_across_multidoc_yaml_files_to_stdout_json_indented"
+        output_dir.mkdir()
+        output_file = output_dir / "output.json"
+
+        # DEBUG
+        # print("LHS File:  {}".format(lhs_file))
+        # print("RHS File:  {}".format(rhs_file))
+        # print("Output File:  {}".format(output_file))
+        # print("Expected Output:")
+        # print(merged_yaml_content)
+
+        result = script_runner.run(
+            self.command
+            , "--nostdin"
+            , "--multi-doc-mode=merge_across"
+            , "--document-format=json"
+            , "--json-indent=4"
+            , lhs_file
+            , rhs_file)
+        assert result.success, result.stderr
+        assert merged_yaml_content == result.stdout
+
+    def test_merge_two_across_multidoc_yaml_files_to_stdout_json_nonindented(self, script_runner, tmp_path, tmp_path_factory):
+        lhs_file = create_temp_yaml_file(tmp_path_factory, """---
+hash:
+  lhs_exclusive: LHS exclusive
+  merge_target: LHS original value
+...
+---
+hash:
+  lhs2_exclusive: LHS2 exclusive
+  merge2_target: LHS2 original value
+""")
+        rhs_file = create_temp_yaml_file(tmp_path_factory, """---
+hash:
+  rhs_exclusive: RHS exclusive
+  merge_target: RHS override value
+...
+---
+hash:
+  rhs2_exclusive: RHS2 exclusive
+  merge_target: RHS2 override value
+  merge2_target: RHS2 2nd override value
+""")
+        merged_yaml_content = """{"hash": {"lhs_exclusive": "LHS exclusive", "rhs_exclusive": "RHS exclusive", "merge_target": "RHS override value"}}
+{"hash": {"lhs2_exclusive": "LHS2 exclusive", "merge2_target": "RHS2 2nd override value", "rhs2_exclusive": "RHS2 exclusive", "merge_target": "RHS2 override value"}}
+"""
+
+        output_dir = tmp_path / "test_merge_two_across_multidoc_yaml_files_to_stdout_json"
+        output_dir.mkdir()
+        output_file = output_dir / "output.json"
+
+        # DEBUG
+        # print("LHS File:  {}".format(lhs_file))
+        # print("RHS File:  {}".format(rhs_file))
+        # print("Output File:  {}".format(output_file))
+        # print("Expected Output:")
+        # print(merged_yaml_content)
+
+        result = script_runner.run(
+            self.command
+            , "--nostdin"
+            , "--multi-doc-mode=merge_across"
+            , "--document-format=json"
+            , "--json-indent=-20"
             , lhs_file
             , rhs_file)
         assert result.success, result.stderr
@@ -665,6 +838,54 @@ hash:
             filedat = fhnd.read()
         assert merged_yaml_content == filedat
 
+    def test_merge_two_happy_json_files_to_file_indented(self, script_runner, tmp_path, tmp_path_factory):
+        lhs_file = create_temp_yaml_file(tmp_path_factory, """{
+  "hash": {
+      "lhs_exclusive": "LHS exclusive",
+      "merge_target": "LHS original value"
+  }
+}
+""")
+        rhs_file = create_temp_yaml_file(tmp_path_factory, """{
+  "hash": {
+      "rhs_exclusive": "RHS exclusive",
+      "merge_target": "RHS override value"
+  }
+}
+""")
+        merged_yaml_content = """{
+    "hash": {
+        "lhs_exclusive": "LHS exclusive",
+        "rhs_exclusive": "RHS exclusive",
+        "merge_target": "RHS override value"
+    }
+}"""
+
+        output_dir = tmp_path / "test_merge_two_happy_json_files_to_file_indented"
+        output_dir.mkdir()
+        output_file = output_dir / "output.yaml"
+
+        # DEBUG
+        # print("LHS File:  {}".format(lhs_file))
+        # print("RHS File:  {}".format(rhs_file))
+        # print("Output File:  {}".format(output_file))
+        # print("Expected Output:")
+        # print(merged_yaml_content)
+
+        result = script_runner.run(
+            self.command
+            , "--nostdin"
+            , "--output={}".format(output_file)
+            , "--document-format=json"
+            , "--json-indent=4"
+            , lhs_file
+            , rhs_file)
+        assert result.success, result.stderr
+
+        with open(output_file, 'r') as fhnd:
+            filedat = fhnd.read()
+        assert merged_yaml_content == filedat
+
     def test_convert_yaml_to_json_file(self, script_runner, tmp_path, tmp_path_factory):
         lhs_file = create_temp_yaml_file(tmp_path_factory, """---
 hash:
@@ -687,6 +908,42 @@ hash:
             self.command
             , "--nostdin"
             , "--document-format=json"
+            , "--output={}".format(output_file)
+            , lhs_file)
+        assert result.success, result.stderr
+
+        with open(output_file, 'r') as fhnd:
+            filedat = fhnd.read()
+        assert merged_yaml_content == filedat
+
+    def test_convert_yaml_to_json_file_indented(self, script_runner, tmp_path, tmp_path_factory):
+        lhs_file = create_temp_yaml_file(tmp_path_factory, """---
+hash:
+  lhs_exclusive: LHS exclusive
+  merge_target: LHS original value
+""")
+        merged_yaml_content = """{
+    "hash": {
+        "lhs_exclusive": "LHS exclusive",
+        "merge_target": "LHS original value"
+    }
+}"""
+
+        output_dir = tmp_path / "test_convert_yaml_to_json_file_indented"
+        output_dir.mkdir()
+        output_file = output_dir / "output.yaml"
+
+        # DEBUG
+        # print("LHS File:  {}".format(lhs_file))
+        # print("Output File:  {}".format(output_file))
+        # print("Expected Output:")
+        # print(merged_yaml_content)
+
+        result = script_runner.run(
+            self.command
+            , "--nostdin"
+            , "--document-format=json"
+            , "--json-indent=4"
             , "--output={}".format(output_file)
             , lhs_file)
         assert result.success, result.stderr
@@ -719,6 +976,45 @@ hash:
             self.command
             , "--nostdin"
             , "--document-format=json"
+            , "--output={}".format(output_file)
+            , lhs_file)
+        assert result.success, result.stderr
+
+        with open(output_file, 'r') as fhnd:
+            filedat = fhnd.read()
+        assert merged_yaml_content == filedat
+
+    def test_convert_yaml_tagged_set_to_json_file_indented(self, script_runner, tmp_path, tmp_path_factory):
+        lhs_file = create_temp_yaml_file(tmp_path_factory, """--- !!set
+? !int 5280
+? !bool false
+? !double 3.1415926535856
+? BareVal
+? !string TaggedVal
+""")
+        merged_yaml_content = """{
+    "5280": null,
+    "false": null,
+    "3.1415926535856": null,
+    "BareVal": null,
+    "TaggedVal": null
+}"""
+
+        output_dir = tmp_path / "test_convert_yaml_tagged_set_to_json_file_indented"
+        output_dir.mkdir()
+        output_file = output_dir / "output.yaml"
+
+        # DEBUG
+        # print("LHS File:  {}".format(lhs_file))
+        # print("Output File:  {}".format(output_file))
+        # print("Expected Output:")
+        # print(merged_yaml_content)
+
+        result = script_runner.run(
+            self.command
+            , "--nostdin"
+            , "--document-format=json"
+            , "--json-indent=4"
             , "--output={}".format(output_file)
             , lhs_file)
         assert result.success, result.stderr
@@ -974,6 +1270,48 @@ hash:
         assert 0 == result.returncode, result.stderr
         assert merged_yaml_content == result.stdout
 
+    def test_merge_implicit_from_stdin_to_stdout_explicit_json_indented(
+        self, script_runner, tmp_path_factory
+    ):
+        import subprocess
+
+        lhs_file = create_temp_yaml_file(tmp_path_factory, """---
+hash:
+  lhs_exclusive: LHS exclusive
+  merge_target: LHS original value
+""")
+        rhs_content = """---
+hash:
+  rhs_exclusive: RHS exclusive
+  merge_target: RHS override value
+"""
+        merged_yaml_content = """{
+    "hash": {
+        "lhs_exclusive": "LHS exclusive",
+        "rhs_exclusive": "RHS exclusive",
+        "merge_target": "RHS override value"
+    }
+}"""
+
+        result = subprocess.run(
+            [self.command
+            , lhs_file
+            , "--document-format=json"
+            , "--json-indent=4"]
+            , stdout=subprocess.PIPE
+            , input=rhs_content
+            , universal_newlines=True
+        )
+
+        # DEBUG
+        # print("Expected:")
+        # print(merged_yaml_content)
+        # print("Got:")
+        # print(result.stdout)
+
+        assert 0 == result.returncode, result.stderr
+        assert merged_yaml_content == result.stdout
+
     def test_bad_mergeat_yamlpath_condense_all(self, script_runner, tmp_path_factory):
         lhs_file = create_temp_yaml_file(tmp_path_factory, """---
 hash:
@@ -1109,6 +1447,81 @@ hash:
             self.command
             , "--nostdin"
             , "--document-format=json"
+            , "--output={}".format(output_file)
+            , lhs_file)
+        assert result.success, result.stderr
+
+        with open(output_file, 'r') as fhnd:
+            filedat = fhnd.read()
+        assert merged_yaml_content == filedat
+
+    def test_merge_yaml_output_json_indented(self, script_runner, tmp_path, tmp_path_factory):
+        lhs_file = create_temp_yaml_file(tmp_path_factory, """---
+aliases:
+  - &some_lhs_string A string value
+
+lhs_anchored_hash: &some_lhs_hash
+  with: properties
+  of_its: own
+
+hash:
+  <<: *some_lhs_hash
+  uses_an_alias: *some_lhs_string
+  lhs_exclusive: LHS exclusive
+  merge_target: LHS original value
+...
+---
+aliases:
+  - &some_rhs_number 5280
+
+rhs_anchored_hash: &some_rhs_hash
+  having: its
+  very_own: properties
+
+hash:
+  <<: *some_rhs_hash
+  uses_an_alias: *some_rhs_number
+  rhs_exclusive: RHS exclusive
+  merge_target: RHS override value
+""")
+        merged_yaml_content = """{
+    "aliases": [
+        "A string value",
+        5280
+    ],
+    "lhs_anchored_hash": {
+        "with": "properties",
+        "of_its": "own"
+    },
+    "rhs_anchored_hash": {
+        "having": "its",
+        "very_own": "properties"
+    },
+    "hash": {
+        "uses_an_alias": 5280,
+        "lhs_exclusive": "LHS exclusive",
+        "rhs_exclusive": "RHS exclusive",
+        "merge_target": "RHS override value",
+        "having": "its",
+        "very_own": "properties"
+    }
+}"""
+
+        output_dir = tmp_path / "test_merge_yaml_output_json_indented"
+        output_dir.mkdir()
+        output_file = output_dir / "output.yaml"
+
+        # DEBUG
+        # print("LHS File:  {}".format(lhs_file))
+        # print("Output File:  {}".format(output_file))
+        # print("Expected Output:")
+        # print(merged_yaml_content)
+
+        result = script_runner.run(
+            self.command
+            , "--nostdin"
+            , "--document-format=json"
+            , "--json-indent=4"
             , "--output={}".format(output_file)
             , lhs_file)
         assert result.success, result.stderr

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1600,6 +1600,51 @@ non_conformant: value
         assert len(results) == matchidx
 
 
+    def test_exists_null_doc(self, quiet_logger):
+        yaml = YAML()
+        processor = Processor(quiet_logger, None)
+
+        try:
+            assert False == processor.exists('**')
+        except YAMLPathException as ex:
+              # Unexpected error
+              assert False
+
+    @pytest.mark.parametrize("yamlpath,pathsep,results", [
+        ("theological_deities", PathSeparators.AUTO, True),
+        (YAMLPath("does_not_exist"), PathSeparators.DOT, False),
+        ("seriously/broken path", PathSeparators.FSLASH, False),
+        ("theological_deities(roman)+(christian)", PathSeparators.AUTO, False),
+    ])
+    def test_exists(self, quiet_logger, yamlpath, pathsep, results):
+        yamldata = """---
+aliases:
+  - &td_g_g_anchor Hera
+
+theological_deities:
+  greek:
+    gods:
+      - Apollo
+      - Demeter
+      - Poseidon
+      - Zeus
+    goddesses:
+      - Aphrodite
+      - Artemis
+      - Athena
+      - *td_g_g_anchor
+"""
+        yaml = YAML()
+        processor = Processor(quiet_logger, yaml.load(yamldata))
+
+        try:
+            path_exists = processor.exists(yamlpath, pathsep=pathsep)
+            assert path_exists == results
+        except YAMLPathException as ex:
+              # Unexpected error
+              assert False
+
+
     @pytest.mark.parametrize("yamlpath,results", [
         (r"temperature[. =~ /\d{3}/]", [110, 100, 114]),
     ])

--- a/yamlpath/__init__.py
+++ b/yamlpath/__init__.py
@@ -1,6 +1,6 @@
 """Core YAML Path classes."""
 # Establish the version number common to all components
-__version__ = "3.7.0"
+__version__ = "3.8.0"
 
 from yamlpath.yamlpath import YAMLPath
 from yamlpath.processor import Processor

--- a/yamlpath/exceptions/__init__.py
+++ b/yamlpath/exceptions/__init__.py
@@ -1,2 +1,14 @@
 """Make all of the custom YAML Path exceptions available."""
 from yamlpath.exceptions.yamlpathexception import YAMLPathException
+from yamlpath.exceptions.badaliasyamlpathexception import (
+    BadAliasYAMLPathException)
+from yamlpath.exceptions.duplicatekeyyamlpathexception import (
+    DuplicateKeyYAMLPathException)
+from yamlpath.exceptions.nodocumentyamlpathexception import (
+    NoDocumentYAMLPathException)
+from yamlpath.exceptions.recursionyamlpathexception import (
+    RecursionYAMLPathException)
+from yamlpath.exceptions.typemismatchyamlpathexception import (
+    TypeMismatchYAMLPathException)
+from yamlpath.exceptions.unmatchedyamlpathexception import (
+    UnmatchedYAMLPathException)

--- a/yamlpath/exceptions/badaliasyamlpathexception.py
+++ b/yamlpath/exceptions/badaliasyamlpathexception.py
@@ -1,0 +1,37 @@
+"""
+Implement BadAliasYAMLPathException.
+
+Copyright 2023 William W. Kimball, Jr. MBA MSIS
+"""
+from typing import Optional
+
+from yamlpath.exceptions.yamlpathexception import YAMLPathException
+
+
+class BadAliasYAMLPathException(YAMLPathException):
+    """
+    Indicate a YAML Path points to an impossible YAML Anchor/Alias/YMK.
+
+    Occurs when a YAML Path is improperly formed or fails to lead to a required
+    YAML node.
+    """
+
+    def __init__(
+        self, user_message: str, yaml_path: str, segment: Optional[str] = None
+    ) -> None:
+        """
+        Initialize this Exception with all pertinent data.
+
+        Parameters:
+        1. user_message (str) The message to convey to the user
+        2. yaml_path (str) The stringified YAML Path which lead to the
+           exception
+        3. segment (Optional[str]) The segment of the YAML Path which triggered
+           the exception, if available
+
+        Returns:  N/A
+
+        Raises:  N/A
+        """
+        super().__init__(
+            user_message=user_message, yaml_path=yaml_path, segment=segment)

--- a/yamlpath/exceptions/duplicatekeyyamlpathexception.py
+++ b/yamlpath/exceptions/duplicatekeyyamlpathexception.py
@@ -1,0 +1,37 @@
+"""
+Implement DuplicateKeyYAMLPathException.
+
+Copyright 2023 William W. Kimball, Jr. MBA MSIS
+"""
+from typing import Optional
+
+from yamlpath.exceptions.yamlpathexception import YAMLPathException
+
+
+class DuplicateKeyYAMLPathException(YAMLPathException):
+    """
+    Indicate a YAML Path operation would violate key uniqueness.
+
+    Occurs when a YAML Path is improperly formed or fails to lead to a required
+    YAML node.
+    """
+
+    def __init__(
+        self, user_message: str, yaml_path: str, segment: Optional[str] = None
+    ) -> None:
+        """
+        Initialize this Exception with all pertinent data.
+
+        Parameters:
+        1. user_message (str) The message to convey to the user
+        2. yaml_path (str) The stringified YAML Path which lead to the
+           exception
+        3. segment (Optional[str]) The segment of the YAML Path which triggered
+           the exception, if available
+
+        Returns:  N/A
+
+        Raises:  N/A
+        """
+        super().__init__(
+            user_message=user_message, yaml_path=yaml_path, segment=segment)

--- a/yamlpath/exceptions/nodocumentyamlpathexception.py
+++ b/yamlpath/exceptions/nodocumentyamlpathexception.py
@@ -1,0 +1,37 @@
+"""
+Implement NoDocumentYAMLPathException.
+
+Copyright 2023 William W. Kimball, Jr. MBA MSIS
+"""
+from typing import Optional
+
+from yamlpath.exceptions.yamlpathexception import YAMLPathException
+
+
+class NoDocumentYAMLPathException(YAMLPathException):
+    """
+    Indicate a YAML Path points to or creates an empty document.
+
+    Occurs when a YAML Path is improperly formed or fails to lead to a required
+    YAML node.
+    """
+
+    def __init__(
+        self, user_message: str, yaml_path: str, segment: Optional[str] = None
+    ) -> None:
+        """
+        Initialize this Exception with all pertinent data.
+
+        Parameters:
+        1. user_message (str) The message to convey to the user
+        2. yaml_path (str) The stringified YAML Path which lead to the
+           exception
+        3. segment (Optional[str]) The segment of the YAML Path which triggered
+           the exception, if available
+
+        Returns:  N/A
+
+        Raises:  N/A
+        """
+        super().__init__(
+            user_message=user_message, yaml_path=yaml_path, segment=segment)

--- a/yamlpath/exceptions/recursionyamlpathexception.py
+++ b/yamlpath/exceptions/recursionyamlpathexception.py
@@ -1,0 +1,37 @@
+"""
+Implement RecursionYAMLPathException.
+
+Copyright 2023 William W. Kimball, Jr. MBA MSIS
+"""
+from typing import Optional
+
+from yamlpath.exceptions.yamlpathexception import YAMLPathException
+
+
+class RecursionYAMLPathException(YAMLPathException):
+    """
+    Indicate a YAML Path causes an inescapable recursion loop.
+
+    Occurs when a YAML Path is improperly formed or fails to lead to a required
+    YAML node.
+    """
+
+    def __init__(
+        self, user_message: str, yaml_path: str, segment: Optional[str] = None
+    ) -> None:
+        """
+        Initialize this Exception with all pertinent data.
+
+        Parameters:
+        1. user_message (str) The message to convey to the user
+        2. yaml_path (str) The stringified YAML Path which lead to the
+           exception
+        3. segment (Optional[str]) The segment of the YAML Path which triggered
+           the exception, if available
+
+        Returns:  N/A
+
+        Raises:  N/A
+        """
+        super().__init__(
+            user_message=user_message, yaml_path=yaml_path, segment=segment)

--- a/yamlpath/exceptions/typemismatchyamlpathexception.py
+++ b/yamlpath/exceptions/typemismatchyamlpathexception.py
@@ -1,0 +1,37 @@
+"""
+Implement TypeMismatchYAMLPathException.
+
+Copyright 2023 William W. Kimball, Jr. MBA MSIS
+"""
+from typing import Optional
+
+from yamlpath.exceptions.yamlpathexception import YAMLPathException
+
+
+class TypeMismatchYAMLPathException(YAMLPathException):
+    """
+    Indicate a YAML Path contains a data-type mismatch.
+
+    Occurs when a YAML Path is improperly formed or fails to lead to a required
+    YAML node.
+    """
+
+    def __init__(
+        self, user_message: str, yaml_path: str, segment: Optional[str] = None
+    ) -> None:
+        """
+        Initialize this Exception with all pertinent data.
+
+        Parameters:
+        1. user_message (str) The message to convey to the user
+        2. yaml_path (str) The stringified YAML Path which lead to the
+           exception
+        3. segment (Optional[str]) The segment of the YAML Path which triggered
+           the exception, if available
+
+        Returns:  N/A
+
+        Raises:  N/A
+        """
+        super().__init__(
+            user_message=user_message, yaml_path=yaml_path, segment=segment)

--- a/yamlpath/exceptions/unmatchedyamlpathexception.py
+++ b/yamlpath/exceptions/unmatchedyamlpathexception.py
@@ -1,0 +1,37 @@
+"""
+Implement UnmatchedYAMLPathException.
+
+Copyright 2023 William W. Kimball, Jr. MBA MSIS
+"""
+from typing import Optional
+
+from yamlpath.exceptions.yamlpathexception import YAMLPathException
+
+
+class UnmatchedYAMLPathException(YAMLPathException):
+    """
+    Indicate a YAML Path points to nothing.
+
+    Occurs when a YAML Path is improperly formed or fails to lead to a required
+    YAML node.
+    """
+
+    def __init__(
+        self, user_message: str, yaml_path: str, segment: Optional[str] = None
+    ) -> None:
+        """
+        Initialize this Exception with all pertinent data.
+
+        Parameters:
+        1. user_message (str) The message to convey to the user
+        2. yaml_path (str) The stringified YAML Path which lead to the
+           exception
+        3. segment (Optional[str]) The segment of the YAML Path which triggered
+           the exception, if available
+
+        Returns:  N/A
+
+        Raises:  N/A
+        """
+        super().__init__(
+            user_message=user_message, yaml_path=yaml_path, segment=segment)

--- a/yamlpath/yamlpath.py
+++ b/yamlpath/yamlpath.py
@@ -8,7 +8,10 @@ from collections import deque
 from typing import Deque, List, Optional, Union
 
 from yamlpath.types import PathAttributes, PathSegment
-from yamlpath.exceptions import YAMLPathException
+from yamlpath.exceptions import (
+    YAMLPathException,
+    TypeMismatchYAMLPathException
+)
 from yamlpath.enums import (
     PathSegmentTypes,
     PathSearchKeywords,
@@ -711,7 +714,7 @@ class YAMLPath:
                     try:
                         idx = int(segment_id)
                     except ValueError as wrap_ex:
-                        raise YAMLPathException((
+                        raise TypeMismatchYAMLPathException((
                             "Not an integer index at character index {}:  {}")
                             .format(char_idx, segment_id)
                             , yaml_path


### PR DESCRIPTION
Enhancements:
* The yaml-set and yaml-merge command-line tools now support a new option:
  --json-indent/-J.  This applies only to JSON output.  By default, JSON
  documents are written/printed as single-line documents.  This new option
  enables users to vertically expand JSON output with a specified indentation
  size for nest levels.
* Additional *YAMLPathExceptions have been added to increase the specificity of
  various error conditions.  You do not need to change any of your code as a
  result of this change; all new exceptions are subclasses of the original
  YAMLPathException.  The new exceptions include:
  * UnmatchedYAMLPathException:  No matching nodes
  * DuplicateKeyYAMLPathException:  Duplicate key creation attempted
  * TypeMismatchYAMLPathException:  Data Type mismatch
  * BadAliasYAMLPathException:  Anchor/Alias/YMK error
  * NoDocumentYAMLPathException:  Attempt to delete the entire document
  * RecursionYAMLPathException:  Recursion nesting error
* The Processor class now enables consumers to verify whether a YAMLPath would
  resolve to at least one node in the present document.  The result is a simple
  Boolean (True when the path resolves; False, otherwise).  The document is not
  modified by this test.  See:  Processor.exists(yaml_path)

Bug Fixes:
* Pursuant to the addition of the intersection operator (&) added in 3.7.0, the
  text of one of the YAMLPathExceptions has been updated:
    Former:
      Adjoining Collectors without an operator has no meaning; try + or -
      between them, {yaml_path}
    New:
      Adjoining Collectors without an operator has no meaning; try +, -, or &
      between them, {yaml_path}
